### PR TITLE
Add a simple initial demo of the repo structure

### DIFF
--- a/configurations/create_csap_pool.py
+++ b/configurations/create_csap_pool.py
@@ -1,0 +1,41 @@
+from core_data_modules.cleaners import somali
+from core_data_modules.cleaners.codes import Codes
+
+from src.pipeline_configuration_spec import *
+
+PIPELINE_CONFIGURATION = PipelineConfiguration(
+    pipeline_name="Create-CSAP-Somalia-Pool",
+    # TODO: Add remaining projects to this description once their configurations are included too.
+    description="Creates the initial CSAP-Somalia pool using demographics flows from EU-PCVE s01, ",
+    engagement_database=EngagementDatabaseClientConfiguration(
+        credentials_file_url="gs://avf-credentials/firebase-test.json",  # TODO: Switch to production
+        database_path="engagement_db_experiments/csap_test"
+    ),
+    uuid_table=UUIDTableClientConfiguration(
+        credentials_file_url="gs://avf-credentials/firebase-test.json",  # TODO: Switch to production
+        table_name="_engagement_db_csap_test",  # TODO: Switch to production
+        uuid_prefix="avf-participant-uuid-"
+    ),
+    operations_dashboard=OperationsDashboardConfiguration(
+        credentials_file_url="gs://avf-credentials/avf-dashboards-firebase-adminsdk-gvecb-ef772e79b6.json",
+    ),
+    rapid_pro_sources=[
+        RapidProSource(
+            rapid_pro=RapidProClientConfiguration(
+                domain="textit.com",
+                token_file_url="gs://avf-credentials/csap-text-it-token.txt"
+            ),
+            sync_config=RapidProToEngagementDBConfiguration(
+                flow_result_configurations=[
+                    # EU-PCVE s01
+                    FlowResultConfiguration("csap_eu_pcve_demog", "location", "csap_location"),
+                    FlowResultConfiguration("csap_eu_pcve_demog", "gender", "csap_gender"),
+                    FlowResultConfiguration("csap_eu_pcve_demog", "age", "csap_age"),
+                    FlowResultConfiguration("csap_eu_pcve_demog", "recently_displaced", "csap_recently_displaced"),
+                    FlowResultConfiguration("csap_eu_pcve_demog", "hh_language", "csap_household_language"),
+                ]
+            )
+        )
+    ],
+    archive_configuration=None
+)

--- a/configurations/docker_image_name.txt
+++ b/configurations/docker_image_name.txt
@@ -1,0 +1,1 @@
+ghcr.io/africasvoices/test-pipeline-engagement-db:docker-registry

--- a/docker-sync-rapid-pro-to-engagement-db.sh
+++ b/docker-sync-rapid-pro-to-engagement-db.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -e
+
+IMAGE_NAME="$(<configurations/docker_image_name.txt)"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN="--dry-run"
+            shift;;
+        --incremental-cache-volume)
+            INCREMENTAL_ARG="--incremental-cache-path /cache"
+            INCREMENTAL_CACHE_VOLUME_NAME="$2"
+            shift 2;;
+        --local-archive)
+            LOCAL_ARCHIVE_PATHS+=("$2")
+            shift 2;;
+        --)
+            shift
+            break;;
+        *)
+            break;;
+    esac
+done
+
+# Check that the correct number of arguments were provided.
+if [[ $# -ne 5 ]]; then
+    echo "Usage: $0
+    [--dry-run] [--incremental-cache-volume <incremental-cache-volume>] 
+    [--local-archive <local_archive>] : set a single option with argument, repeat it multiple times
+    <user> <google-cloud-credentials-file-path> <configuration-file> <code-schemes-dir> <data-dir>"
+    exit
+fi
+
+# Assign the program arguments to bash variables.
+USER=$1
+GOOGLE_CLOUD_CREDENTIALS_PATH=$2
+CONFIGURATION_FILE=$3
+CODE_SCHEMES_DIR=$4
+DATA_DIR=$5
+
+# Set local archive arguments if specified
+LOCAL_ARCHIVE_ARGS=""
+for LOCAL_ARCHIVE_PATH in "${LOCAL_ARCHIVE_PATHS[@]}"; do
+    IFS="=" # Setting equal sign as delimiter 
+    read -a strarr <<<"$LOCAL_ARCHIVE_PATH" # Reading str as an array of tokens separated by IFS 
+    gs_url=${strarr[0]}; local_archive_dir=$(basename ${strarr[1]})
+    LOCAL_ARCHIVE_ARGS+=" --local-archive $gs_url=/$local_archive_dir"
+done
+
+# Create a container from the image that was just built.
+CMD="pipenv run python -u sync_rapid_pro_to_engagement_db.py ${DRY_RUN} ${INCREMENTAL_ARG} ${LOCAL_ARCHIVE_ARGS} \
+    ${USER} /credentials/google-cloud-credentials.json configuration"
+
+if [[ "$INCREMENTAL_ARG" ]]; then
+    container="$(docker container create -w /app --mount source="$INCREMENTAL_CACHE_VOLUME_NAME",target=/cache "$IMAGE_NAME" /bin/bash -c "$CMD")"
+else
+    container="$(docker container create -w /app "$IMAGE_NAME" /bin/bash -c "$CMD")"
+fi
+
+echo "Created container $container"
+container_short_id=${container:0:7}
+
+# Copy input data into the container
+echo "Copying $GOOGLE_CLOUD_CREDENTIALS_PATH -> $container_short_id:/credentials/google-cloud-credentials.json"
+docker cp "$GOOGLE_CLOUD_CREDENTIALS_PATH" "$container:/credentials/google-cloud-credentials.json"
+
+echo "Copying $CODE_SCHEMES_DIR -> $container_short_id:/app/code_schemes"
+docker cp "$CODE_SCHEMES_DIR" "$container:/app/code_schemes"
+
+echo "Copying $CONFIGURATION_FILE -> $container_short_id:/app/configuration.py"
+docker cp "$CONFIGURATION_FILE" "$container:/app/configuration.py"
+
+for LOCAL_ARCHIVE_PATH in "${LOCAL_ARCHIVE_PATHS[@]}"; do
+    IFS="=" # Setting equal sign as delimiter 
+    read -a strarr <<<"$LOCAL_ARCHIVE_PATH" # Reading str as an array of tokens separated by IFS 
+    
+    # Expand the tilde character to home directory if available
+    path=$(pipenv run python -c "import os.path; print(os.path.expanduser(\"${strarr[1]}\"))")
+    local_archive_dir=$(basename $path)
+    
+    echo "Copying $path -> $container_short_id:/$local_archive_dir"
+    docker cp "$path" "$container:/$local_archive_dir"
+done
+
+# Run the container
+echo "Starting container $container_short_id"
+docker start -a -i "$container"
+
+# Copy cache data out of the container for backup
+if [[ "$INCREMENTAL_ARG" ]]; then
+    echo "Copying $container_short_id:/cache/. -> $DATA_DIR/Cache"
+    mkdir -p "$DATA_DIR/Cache"
+    docker cp "$container:/cache/." "$DATA_DIR/Cache"
+fi
+
+# Tear down the container when it has run successfully
+docker container rm "$container" >/dev/null


### PR DESCRIPTION
This demo runs a rapid pro -> db sync for the eu s01 demographics, using the image built by https://github.com/AfricasVoices/Test-Pipeline-Engagement-DB/pull/166. Completing the set-up will just require some more docker scripts, code schemes, and configuration, following exactly the same pattern as established here. No src needed :)

To choose which version of the image to run, edit docker_image_name.txt. This will usually be a github version tag, but could also be a github branch name or build id for beta releases, as shown here.

The docker script is mostly copy-paste from the test-pipeline-engagement-db repo, but with the docker build and tag step removed.

To run against a local development build, you could do something like `docker build -t test-pipeline-engagement-db:dev .` in your local checkout of the test pipeline repo, then temporarily change docker_image_name.txt to contain `test-pipeline-engagement-db:dev`.

Finally, if we find this approach really isn't working, or we need to make a drastic local change, it is straightforward to "eject" from this configuration simply by copying and pasting in the source code and docker scripts from the test pipeline then modifying from there.