### PR TITLE
Add previous code schemes

### DIFF
--- a/code_schemes/csap_operator.json
+++ b/code_schemes/csap_operator.json
@@ -1,0 +1,111 @@
+{
+  "SchemeID": "Scheme-f86cff0b",
+  "Name": "CSAP Operator",
+  "Version": "0.0.1.0",
+  "Codes": [
+    {
+      "CodeID": "code-450ec146",
+      "CodeType": "Normal",
+      "DisplayText": "golis",
+      "NumericValue": 1,
+      "StringValue": "golis",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "golis"
+      ]
+    },
+    {
+      "CodeID": "code-c7b32481",
+      "CodeType": "Normal",
+      "DisplayText": "hormud",
+      "NumericValue": 2,
+      "StringValue": "hormud",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "hormud"
+      ]
+    },
+    {
+      "CodeID": "code-b83b9be1",
+      "CodeType": "Normal",
+      "DisplayText": "nationlink",
+      "NumericValue": 3,
+      "StringValue": "nationlink",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "nationlink"
+      ]
+    },
+    {
+      "CodeID": "code-524167c7",
+      "CodeType": "Normal",
+      "DisplayText": "somnet",
+      "NumericValue": 4,
+      "StringValue": "somnet",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "somnet"
+      ]
+    },
+    {
+      "CodeID": "code-605d77ed",
+      "CodeType": "Normal",
+      "DisplayText": "somtel",
+      "NumericValue": 5,
+      "StringValue": "somtel",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "somtel"
+      ]
+    },
+    {
+      "CodeID": "code-3e6ddc70",
+      "CodeType": "Normal",
+      "DisplayText": "telesom",
+      "NumericValue": 6,
+      "StringValue": "telesom",
+      "VisibleInCoda": true,
+      "MatchValues":  [
+        "telesom"
+      ]
+    },
+    {
+      "CodeID": "code-9aaa32b2",
+      "CodeType": "Normal",
+      "DisplayText": "telegram",
+      "NumericValue": 7,
+      "StringValue": "telegram",
+      "VisibleInCoda": true,
+      "MatchValues":  [
+        "telegram"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": false
+    }
+  ]
+}

--- a/code_schemes/demographics/age.json
+++ b/code_schemes/demographics/age.json
@@ -1,0 +1,1177 @@
+{
+  "SchemeID": "Scheme-4189e74c",
+  "Name": "Age",
+  "Version": "0.0.0.4",
+  "Codes": [
+    {
+      "CodeID": "code-a3305435",
+      "CodeType": "Normal",
+      "DisplayText": "10",
+      "NumericValue": 10,
+      "StringValue": "10",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "10"
+      ]
+    },
+    {
+      "CodeID": "code-da61caa4",
+      "CodeType": "Normal",
+      "DisplayText": "11",
+      "NumericValue": 11,
+      "StringValue": "11",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "11"
+      ]
+    },
+    {
+      "CodeID": "code-48fca137",
+      "CodeType": "Normal",
+      "DisplayText": "12",
+      "NumericValue": 12,
+      "StringValue": "12",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "12"
+      ]
+    },
+    {
+      "CodeID": "code-3fe12b55",
+      "CodeType": "Normal",
+      "DisplayText": "13",
+      "NumericValue": 13,
+      "StringValue": "13",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "13"
+      ]
+    },
+    {
+      "CodeID": "code-a800738e",
+      "CodeType": "Normal",
+      "DisplayText": "14",
+      "NumericValue": 14,
+      "StringValue": "14",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "14"
+      ]
+    },
+    {
+      "CodeID": "code-3974fd97",
+      "CodeType": "Normal",
+      "DisplayText": "15",
+      "NumericValue": 15,
+      "StringValue": "15",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "15"
+      ]
+    },
+    {
+      "CodeID": "code-dfb81fb8",
+      "CodeType": "Normal",
+      "DisplayText": "16",
+      "NumericValue": 16,
+      "StringValue": "16",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "16"
+      ]
+    },
+    {
+      "CodeID": "code-ba009721",
+      "CodeType": "Normal",
+      "DisplayText": "17",
+      "NumericValue": 17,
+      "StringValue": "17",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "17"
+      ]
+    },
+    {
+      "CodeID": "code-1c301f52",
+      "CodeType": "Normal",
+      "DisplayText": "18",
+      "NumericValue": 18,
+      "StringValue": "18",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "18"
+      ]
+    },
+    {
+      "CodeID": "code-611f7707",
+      "CodeType": "Normal",
+      "DisplayText": "19",
+      "NumericValue": 19,
+      "StringValue": "19",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "19"
+      ]
+    },
+    {
+      "CodeID": "code-86085ec1",
+      "CodeType": "Normal",
+      "DisplayText": "20",
+      "NumericValue": 20,
+      "StringValue": "20",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "20"
+      ]
+    },
+    {
+      "CodeID": "code-99612198",
+      "CodeType": "Normal",
+      "DisplayText": "21",
+      "NumericValue": 21,
+      "StringValue": "21",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "21"
+      ]
+    },
+    {
+      "CodeID": "code-21138648",
+      "CodeType": "Normal",
+      "DisplayText": "22",
+      "NumericValue": 22,
+      "StringValue": "22",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "22"
+      ]
+    },
+    {
+      "CodeID": "code-96c4c617",
+      "CodeType": "Normal",
+      "DisplayText": "23",
+      "NumericValue": 23,
+      "StringValue": "23",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "23"
+      ]
+    },
+    {
+      "CodeID": "code-c38728ac",
+      "CodeType": "Normal",
+      "DisplayText": "24",
+      "NumericValue": 24,
+      "StringValue": "24",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "24"
+      ]
+    },
+    {
+      "CodeID": "code-47558a0f",
+      "CodeType": "Normal",
+      "DisplayText": "25",
+      "NumericValue": 25,
+      "StringValue": "25",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "25"
+      ]
+    },
+    {
+      "CodeID": "code-b2d12ec2",
+      "CodeType": "Normal",
+      "DisplayText": "26",
+      "NumericValue": 26,
+      "StringValue": "26",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "26"
+      ]
+    },
+    {
+      "CodeID": "code-1a81268e",
+      "CodeType": "Normal",
+      "DisplayText": "27",
+      "NumericValue": 27,
+      "StringValue": "27",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "27"
+      ]
+    },
+    {
+      "CodeID": "code-b8f4f830",
+      "CodeType": "Normal",
+      "DisplayText": "28",
+      "NumericValue": 28,
+      "StringValue": "28",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "28"
+      ]
+    },
+    {
+      "CodeID": "code-64c0bc1e",
+      "CodeType": "Normal",
+      "DisplayText": "29",
+      "NumericValue": 29,
+      "StringValue": "29",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "29"
+      ]
+    },
+    {
+      "CodeID": "code-65107395",
+      "CodeType": "Normal",
+      "DisplayText": "30",
+      "NumericValue": 30,
+      "StringValue": "30",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "30"
+      ]
+    },
+    {
+      "CodeID": "code-8684db85",
+      "CodeType": "Normal",
+      "DisplayText": "31",
+      "NumericValue": 31,
+      "StringValue": "31",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "31"
+      ]
+    },
+    {
+      "CodeID": "code-15100f11",
+      "CodeType": "Normal",
+      "DisplayText": "32",
+      "NumericValue": 32,
+      "StringValue": "32",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "32"
+      ]
+    },
+    {
+      "CodeID": "code-e505941c",
+      "CodeType": "Normal",
+      "DisplayText": "33",
+      "NumericValue": 33,
+      "StringValue": "33",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "33"
+      ]
+    },
+    {
+      "CodeID": "code-758f33ca",
+      "CodeType": "Normal",
+      "DisplayText": "34",
+      "NumericValue": 34,
+      "StringValue": "34",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "34"
+      ]
+    },
+    {
+      "CodeID": "code-47411ccc",
+      "CodeType": "Normal",
+      "DisplayText": "35",
+      "NumericValue": 35,
+      "StringValue": "35",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "35"
+      ]
+    },
+    {
+      "CodeID": "code-91212abb",
+      "CodeType": "Normal",
+      "DisplayText": "36",
+      "NumericValue": 36,
+      "StringValue": "36",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "36"
+      ]
+    },
+    {
+      "CodeID": "code-9ca299d3",
+      "CodeType": "Normal",
+      "DisplayText": "37",
+      "NumericValue": 37,
+      "StringValue": "37",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "37"
+      ]
+    },
+    {
+      "CodeID": "code-3af3f3bc",
+      "CodeType": "Normal",
+      "DisplayText": "38",
+      "NumericValue": 38,
+      "StringValue": "38",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "38"
+      ]
+    },
+    {
+      "CodeID": "code-a3ffb8eb",
+      "CodeType": "Normal",
+      "DisplayText": "39",
+      "NumericValue": 39,
+      "StringValue": "39",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "39"
+      ]
+    },
+    {
+      "CodeID": "code-43536bdb",
+      "CodeType": "Normal",
+      "DisplayText": "40",
+      "NumericValue": 40,
+      "StringValue": "40",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "40"
+      ]
+    },
+    {
+      "CodeID": "code-8c3a380a",
+      "CodeType": "Normal",
+      "DisplayText": "41",
+      "NumericValue": 41,
+      "StringValue": "41",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "41"
+      ]
+    },
+    {
+      "CodeID": "code-582a8f6b",
+      "CodeType": "Normal",
+      "DisplayText": "42",
+      "NumericValue": 42,
+      "StringValue": "42",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "42"
+      ]
+    },
+    {
+      "CodeID": "code-67a69d7e",
+      "CodeType": "Normal",
+      "DisplayText": "43",
+      "NumericValue": 43,
+      "StringValue": "43",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "43"
+      ]
+    },
+    {
+      "CodeID": "code-155ce717",
+      "CodeType": "Normal",
+      "DisplayText": "44",
+      "NumericValue": 44,
+      "StringValue": "44",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "44"
+      ]
+    },
+    {
+      "CodeID": "code-8c03003d",
+      "CodeType": "Normal",
+      "DisplayText": "45",
+      "NumericValue": 45,
+      "StringValue": "45",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "45"
+      ]
+    },
+    {
+      "CodeID": "code-d137606e",
+      "CodeType": "Normal",
+      "DisplayText": "46",
+      "NumericValue": 46,
+      "StringValue": "46",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "46"
+      ]
+    },
+    {
+      "CodeID": "code-acb6ec83",
+      "CodeType": "Normal",
+      "DisplayText": "47",
+      "NumericValue": 47,
+      "StringValue": "47",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "47"
+      ]
+    },
+    {
+      "CodeID": "code-d43b4984",
+      "CodeType": "Normal",
+      "DisplayText": "48",
+      "NumericValue": 48,
+      "StringValue": "48",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "48"
+      ]
+    },
+    {
+      "CodeID": "code-83f41b8a",
+      "CodeType": "Normal",
+      "DisplayText": "49",
+      "NumericValue": 49,
+      "StringValue": "49",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "49"
+      ]
+    },
+    {
+      "CodeID": "code-78ee8e09",
+      "CodeType": "Normal",
+      "DisplayText": "50",
+      "NumericValue": 50,
+      "StringValue": "50",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "50"
+      ]
+    },
+    {
+      "CodeID": "code-d2de461a",
+      "CodeType": "Normal",
+      "DisplayText": "51",
+      "NumericValue": 51,
+      "StringValue": "51",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "51"
+      ]
+    },
+    {
+      "CodeID": "code-69e9ba61",
+      "CodeType": "Normal",
+      "DisplayText": "52",
+      "NumericValue": 52,
+      "StringValue": "52",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "52"
+      ]
+    },
+    {
+      "CodeID": "code-410c8b0b",
+      "CodeType": "Normal",
+      "DisplayText": "53",
+      "NumericValue": 53,
+      "StringValue": "53",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "53"
+      ]
+    },
+    {
+      "CodeID": "code-153ba3ca",
+      "CodeType": "Normal",
+      "DisplayText": "54",
+      "NumericValue": 54,
+      "StringValue": "54",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "54"
+      ]
+    },
+    {
+      "CodeID": "code-a058d8b7",
+      "CodeType": "Normal",
+      "DisplayText": "55",
+      "NumericValue": 55,
+      "StringValue": "55",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "55"
+      ]
+    },
+    {
+      "CodeID": "code-dfacc203",
+      "CodeType": "Normal",
+      "DisplayText": "56",
+      "NumericValue": 56,
+      "StringValue": "56",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "56"
+      ]
+    },
+    {
+      "CodeID": "code-6aeda7b0",
+      "CodeType": "Normal",
+      "DisplayText": "57",
+      "NumericValue": 57,
+      "StringValue": "57",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "57"
+      ]
+    },
+    {
+      "CodeID": "code-dce4076b",
+      "CodeType": "Normal",
+      "DisplayText": "58",
+      "NumericValue": 58,
+      "StringValue": "58",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "58"
+      ]
+    },
+    {
+      "CodeID": "code-bf2545e6",
+      "CodeType": "Normal",
+      "DisplayText": "59",
+      "NumericValue": 59,
+      "StringValue": "59",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "59"
+      ]
+    },
+    {
+      "CodeID": "code-82b7f5da",
+      "CodeType": "Normal",
+      "DisplayText": "60",
+      "NumericValue": 60,
+      "StringValue": "60",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "60"
+      ]
+    },
+    {
+      "CodeID": "code-ff99c651",
+      "CodeType": "Normal",
+      "DisplayText": "61",
+      "NumericValue": 61,
+      "StringValue": "61",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "61"
+      ]
+    },
+    {
+      "CodeID": "code-d74ef454",
+      "CodeType": "Normal",
+      "DisplayText": "62",
+      "NumericValue": 62,
+      "StringValue": "62",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "62"
+      ]
+    },
+    {
+      "CodeID": "code-53534823",
+      "CodeType": "Normal",
+      "DisplayText": "63",
+      "NumericValue": 63,
+      "StringValue": "63",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "63"
+      ]
+    },
+    {
+      "CodeID": "code-b5f21247",
+      "CodeType": "Normal",
+      "DisplayText": "64",
+      "NumericValue": 64,
+      "StringValue": "64",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "64"
+      ]
+    },
+    {
+      "CodeID": "code-b2f491d4",
+      "CodeType": "Normal",
+      "DisplayText": "65",
+      "NumericValue": 65,
+      "StringValue": "65",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "65"
+      ]
+    },
+    {
+      "CodeID": "code-de5fbf60",
+      "CodeType": "Normal",
+      "DisplayText": "66",
+      "NumericValue": 66,
+      "StringValue": "66",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "66"
+      ]
+    },
+    {
+      "CodeID": "code-539f2239",
+      "CodeType": "Normal",
+      "DisplayText": "67",
+      "NumericValue": 67,
+      "StringValue": "67",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "67"
+      ]
+    },
+    {
+      "CodeID": "code-7b4d3a0e",
+      "CodeType": "Normal",
+      "DisplayText": "68",
+      "NumericValue": 68,
+      "StringValue": "68",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "68"
+      ]
+    },
+    {
+      "CodeID": "code-a42b0a69",
+      "CodeType": "Normal",
+      "DisplayText": "69",
+      "NumericValue": 69,
+      "StringValue": "69",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "69"
+      ]
+    },
+    {
+      "CodeID": "code-64c24042",
+      "CodeType": "Normal",
+      "DisplayText": "70",
+      "NumericValue": 70,
+      "StringValue": "70",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "70"
+      ]
+    },
+    {
+      "CodeID": "code-3cafd342",
+      "CodeType": "Normal",
+      "DisplayText": "71",
+      "NumericValue": 71,
+      "StringValue": "71",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "71"
+      ]
+    },
+    {
+      "CodeID": "code-50672e04",
+      "CodeType": "Normal",
+      "DisplayText": "72",
+      "NumericValue": 72,
+      "StringValue": "72",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "72"
+      ]
+    },
+    {
+      "CodeID": "code-74878f0b",
+      "CodeType": "Normal",
+      "DisplayText": "73",
+      "NumericValue": 73,
+      "StringValue": "73",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "73"
+      ]
+    },
+    {
+      "CodeID": "code-dd1cf2d2",
+      "CodeType": "Normal",
+      "DisplayText": "74",
+      "NumericValue": 74,
+      "StringValue": "74",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "74"
+      ]
+    },
+    {
+      "CodeID": "code-f8a7e88f",
+      "CodeType": "Normal",
+      "DisplayText": "75",
+      "NumericValue": 75,
+      "StringValue": "75",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "75"
+      ]
+    },
+    {
+      "CodeID": "code-a7d16804",
+      "CodeType": "Normal",
+      "DisplayText": "76",
+      "NumericValue": 76,
+      "StringValue": "76",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "76"
+      ]
+    },
+    {
+      "CodeID": "code-41835b91",
+      "CodeType": "Normal",
+      "DisplayText": "77",
+      "NumericValue": 77,
+      "StringValue": "77",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "77"
+      ]
+    },
+    {
+      "CodeID": "code-0684d296",
+      "CodeType": "Normal",
+      "DisplayText": "78",
+      "NumericValue": 78,
+      "StringValue": "78",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "78"
+      ]
+    },
+    {
+      "CodeID": "code-f602771d",
+      "CodeType": "Normal",
+      "DisplayText": "79",
+      "NumericValue": 79,
+      "StringValue": "79",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "79"
+      ]
+    },
+    {
+      "CodeID": "code-578e10c9",
+      "CodeType": "Normal",
+      "DisplayText": "80",
+      "NumericValue": 80,
+      "StringValue": "80",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "80"
+      ]
+    },
+    {
+      "CodeID": "code-f38f5850",
+      "CodeType": "Normal",
+      "DisplayText": "81",
+      "NumericValue": 81,
+      "StringValue": "81",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "81"
+      ]
+    },
+    {
+      "CodeID": "code-6e0c16d2",
+      "CodeType": "Normal",
+      "DisplayText": "82",
+      "NumericValue": 82,
+      "StringValue": "82",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "82"
+      ]
+    },
+    {
+      "CodeID": "code-02553fdc",
+      "CodeType": "Normal",
+      "DisplayText": "83",
+      "NumericValue": 83,
+      "StringValue": "83",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "83"
+      ]
+    },
+    {
+      "CodeID": "code-a586776d",
+      "CodeType": "Normal",
+      "DisplayText": "84",
+      "NumericValue": 84,
+      "StringValue": "84",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "84"
+      ]
+    },
+    {
+      "CodeID": "code-017bf47a",
+      "CodeType": "Normal",
+      "DisplayText": "85",
+      "NumericValue": 85,
+      "StringValue": "85",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "85"
+      ]
+    },
+    {
+      "CodeID": "code-ee52b0b0",
+      "CodeType": "Normal",
+      "DisplayText": "86",
+      "NumericValue": 86,
+      "StringValue": "86",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "86"
+      ]
+    },
+    {
+      "CodeID": "code-6d7d3595",
+      "CodeType": "Normal",
+      "DisplayText": "87",
+      "NumericValue": 87,
+      "StringValue": "87",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "87"
+      ]
+    },
+    {
+      "CodeID": "code-be368793",
+      "CodeType": "Normal",
+      "DisplayText": "88",
+      "NumericValue": 88,
+      "StringValue": "88",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "88"
+      ]
+    },
+    {
+      "CodeID": "code-a23c339b",
+      "CodeType": "Normal",
+      "DisplayText": "89",
+      "NumericValue": 89,
+      "StringValue": "89",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "89"
+      ]
+    },
+    {
+      "CodeID": "code-40cb634b",
+      "CodeType": "Normal",
+      "DisplayText": "90",
+      "NumericValue": 90,
+      "StringValue": "90",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "90"
+      ]
+    },
+    {
+      "CodeID": "code-37fd292b",
+      "CodeType": "Normal",
+      "DisplayText": "91",
+      "NumericValue": 91,
+      "StringValue": "91",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "91"
+      ]
+    },
+    {
+      "CodeID": "code-799f6908",
+      "CodeType": "Normal",
+      "DisplayText": "92",
+      "NumericValue": 92,
+      "StringValue": "92",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "92"
+      ]
+    },
+    {
+      "CodeID": "code-01c71faf",
+      "CodeType": "Normal",
+      "DisplayText": "93",
+      "NumericValue": 93,
+      "StringValue": "93",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "93"
+      ]
+    },
+    {
+      "CodeID": "code-e8ed1956",
+      "CodeType": "Normal",
+      "DisplayText": "94",
+      "NumericValue": 94,
+      "StringValue": "94",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "94"
+      ]
+    },
+    {
+      "CodeID": "code-d4753bfa",
+      "CodeType": "Normal",
+      "DisplayText": "95",
+      "NumericValue": 95,
+      "StringValue": "95",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "95"
+      ]
+    },
+    {
+      "CodeID": "code-51ac3e78",
+      "CodeType": "Normal",
+      "DisplayText": "96",
+      "NumericValue": 96,
+      "StringValue": "96",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "96"
+      ]
+    },
+    {
+      "CodeID": "code-5c30d7bf",
+      "CodeType": "Normal",
+      "DisplayText": "97",
+      "NumericValue": 97,
+      "StringValue": "97",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "97"
+      ]
+    },
+    {
+      "CodeID": "code-7bc64328",
+      "CodeType": "Normal",
+      "DisplayText": "98",
+      "NumericValue": 98,
+      "StringValue": "98",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "98"
+      ]
+    },
+    {
+      "CodeID": "code-36856c7f",
+      "CodeType": "Normal",
+      "DisplayText": "99",
+      "NumericValue": 99,
+      "StringValue": "99",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "99"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/demographics/age_category.json
+++ b/code_schemes/demographics/age_category.json
@@ -1,0 +1,242 @@
+{
+  "SchemeID": "Scheme-eea1ce89",
+  "Name": "Age Category",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-aa2640e7",
+      "CodeType": "Normal",
+      "DisplayText": "10 to 14",
+      "NumericValue": 1,
+      "StringValue": "10_to_14",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "10 to 14"
+      ]
+    },
+    {
+      "CodeID": "code-57391e8f",
+      "CodeType": "Normal",
+      "DisplayText": "15 to 17",
+      "NumericValue": 2,
+      "StringValue": "15_to_17",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "15 to 17"
+      ]
+    },
+    {
+      "CodeID": "code-ef3c9330",
+      "CodeType": "Normal",
+      "DisplayText": "18 to 35",
+      "NumericValue": 3,
+      "StringValue": "18_to_35",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "18 to 35"
+      ]
+    },
+    {
+      "CodeID": "code-494d7659",
+      "CodeType": "Normal",
+      "DisplayText": "36 to 54",
+      "NumericValue": 4,
+      "StringValue": "36_to_54",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "36 to 54"
+      ]
+    },
+    {
+      "CodeID": "code-968879ef",
+      "CodeType": "Normal",
+      "DisplayText": "55 to 99",
+      "NumericValue": 5,
+      "StringValue": "55_to_99",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "55 to 99"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/demographics/gender.json
+++ b/code_schemes/demographics/gender.json
@@ -1,0 +1,213 @@
+{
+  "SchemeID": "Scheme-12cb6f95",
+  "Name": "Gender",
+  "Version": "0.0.0.6",
+  "Codes": [
+    {
+      "CodeID": "code-63dcde9a",
+      "CodeType": "Normal",
+      "DisplayText": "man",
+      "NumericValue": 1,
+      "StringValue": "man",
+      "Shortcut": "m",
+      "VisibleInCoda": true,
+      "MatchValues" : [
+        "male",
+        "man"
+      ]
+    },
+    {
+      "CodeID": "code-86a4602c",
+      "CodeType": "Normal",
+      "DisplayText": "woman",
+      "NumericValue": 2,
+      "StringValue" : "woman",
+      "Shortcut": "w",
+      "VisibleInCoda": true,
+      "MatchValues" : [
+        "female",
+        "woman"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/demographics/household_language.json
+++ b/code_schemes/demographics/household_language.json
@@ -1,0 +1,260 @@
+{
+  "SchemeID": "Scheme-e3290e1f",
+  "Name": "Household Language",
+  "Version": "0.0.0.3",
+  "Codes": [
+    {
+      "CodeID": "code-23cf3616",
+      "CodeType": "Normal",
+      "DisplayText": "somali",
+      "NumericValue": 1,
+      "StringValue": "somali",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-83d97143",
+      "CodeType": "Normal",
+      "DisplayText": "mother-tongue",
+      "NumericValue": 2,
+      "StringValue": "mother-tongue",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-ee4f6f30",
+      "CodeType": "Normal",
+      "DisplayText": "english",
+      "NumericValue": 3,
+      "StringValue": "english",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-cf7da7d2",
+      "CodeType": "Normal",
+      "DisplayText": "kiswahili",
+      "NumericValue": 4,
+      "StringValue": "kiswahili",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-92844263",
+      "CodeType": "Normal",
+      "DisplayText": "arabic",
+      "NumericValue": 5,
+      "StringValue": "arabic",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-f61048db",
+      "CodeType": "Normal",
+      "DisplayText": "maimai",
+      "NumericValue": 6,
+      "StringValue": "maimai",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-b190b739",
+      "CodeType": "Normal",
+      "DisplayText": "barawe",
+      "NumericValue": 7,
+      "StringValue": "barawe",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-49087f30",
+      "CodeType": "Normal",
+      "DisplayText": "other theme",
+      "NumericValue": 8,
+      "StringValue": "other_theme",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-2405e210",
+      "CodeType": "Normal",
+      "DisplayText": "multiple languages",
+      "NumericValue": 100,
+      "StringValue": "multiple_languages",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    }
+  ]
+}
+

--- a/code_schemes/demographics/in_idp_camp.json
+++ b/code_schemes/demographics/in_idp_camp.json
@@ -1,0 +1,175 @@
+{
+  "SchemeID": "Scheme-0fe57c6d",
+  "Name": "In IDP Camp",
+  "Version": "0.0.0.4",
+  "Codes": [
+    {
+      "CodeID": "code-dc43b68e",
+      "CodeType": "Normal",
+      "DisplayText": "yes",
+      "NumericValue": 1,
+      "StringValue": "yes",
+      "Shortcut": "y",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "yes"
+      ]
+    },
+    {
+      "CodeID": "code-5d5708c8",
+      "CodeType": "Normal",
+      "DisplayText": "no",
+      "Shortcut": "n",
+      "NumericValue": 2,
+      "StringValue": "no",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "no"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/demographics/livelihood.json
+++ b/code_schemes/demographics/livelihood.json
@@ -1,0 +1,271 @@
+{
+  "SchemeID": "Scheme-717aa67b",
+  "Name": "Livelihood",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-4f3656ff",
+      "CodeType": "Normal",
+      "DisplayText": "teacher",
+      "NumericValue": 1,
+      "StringValue": "teacher",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-d0f6a12c",
+      "CodeType": "Normal",
+      "DisplayText": "farmer",
+      "NumericValue": 2,
+      "StringValue": "farmer",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-a463aab4",
+      "CodeType": "Normal",
+      "DisplayText": "business person",
+      "NumericValue": 3,
+      "StringValue": "business_person",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-602f0ae1",
+      "CodeType": "Normal",
+      "DisplayText": "casual workers",
+      "NumericValue": 4,
+      "StringValue": "casual_workers",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-7abf66dd",
+      "CodeType": "Normal",
+      "DisplayText": "soldier",
+      "NumericValue": 5,
+      "StringValue": "soldier",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-6c0a9f70",
+      "CodeType": "Normal",
+      "DisplayText": "student",
+      "NumericValue": 6,
+      "StringValue": "student",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-6beff7b0",
+      "CodeType": "Normal",
+      "DisplayText": "stay at home",
+      "NumericValue": 7,
+      "StringValue": "stay_at_home",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-b912dc03",
+      "CodeType": "Normal",
+      "DisplayText": "health worker",
+      "NumericValue": 8,
+      "StringValue": "health_worker",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-7e94e73b",
+      "CodeType": "Normal",
+      "DisplayText": "jobless",
+      "NumericValue": 9,
+      "StringValue": "jobless",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-4a520a30",
+      "CodeType": "Normal",
+      "DisplayText": "livestock keeper",
+      "NumericValue": 11,
+      "StringValue": "livestock_keeper",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-09ba3368",
+      "CodeType": "Normal",
+      "DisplayText": "god is my provider",
+      "NumericValue": 12,
+      "StringValue": "god_is_my_provider",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-7717070e",
+      "CodeType": "Normal",
+      "DisplayText": "office worker",
+      "NumericValue": 13,
+      "StringValue": "office_worker",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-0b04d708",
+      "CodeType": "Normal",
+      "DisplayText": "my parents",
+      "NumericValue": 14,
+      "StringValue": "my_parents",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-0489ffde",
+      "CodeType": "Normal",
+      "DisplayText": "my husband",
+      "NumericValue": 15,
+      "StringValue": "my_husband",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-bdb17ff3",
+      "CodeType": "Normal",
+      "DisplayText": "other",
+      "NumericValue": 10,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/demographics/mogadishu_sub_district.json
+++ b/code_schemes/demographics/mogadishu_sub_district.json
@@ -1,0 +1,374 @@
+{
+  "SchemeID": "Scheme-07dfc611",
+  "Name": "Mogadishu Sub-District",
+  "Version": "0.0.0.6",
+  "Codes": [
+    {
+      "CodeID": "code-d170504a",
+      "CodeType": "Normal",
+      "DisplayText": "boondheere",
+      "StringValue": "boondheere",
+      "NumericValue": 1,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "boondheere"
+      ]
+    },
+    {
+      "CodeID": "code-6a343003",
+      "CodeType": "Normal",
+      "DisplayText": "cabdlcasiis",
+      "StringValue": "cabdlcasiis",
+      "NumericValue": 2,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "cabdlcasiis"
+      ]
+    },
+    {
+      "CodeID": "code-d43c2e7a",
+      "CodeType": "Normal",
+      "DisplayText": "daynile",
+      "StringValue": "daynile",
+      "NumericValue": 3,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "daynile"
+      ]
+    },
+    {
+      "CodeID": "code-e72eee9b",
+      "CodeType": "Normal",
+      "DisplayText": "dharkenley",
+      "StringValue": "dharkenley",
+      "NumericValue": 4,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "dharkenley"
+      ]
+    },
+    {
+      "CodeID": "code-1333e076",
+      "CodeType": "Normal",
+      "DisplayText": "heliwa",
+      "StringValue": "heliwa",
+      "NumericValue": 5,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "heliwa"
+      ]
+    },
+    {
+      "CodeID": "code-ae4b5ca2",
+      "CodeType": "Normal",
+      "DisplayText": "hodan",
+      "StringValue": "hodan",
+      "NumericValue": 6,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "hodan"
+      ]
+    },
+    {
+      "CodeID": "code-f8845af1",
+      "CodeType": "Normal",
+      "DisplayText": "hawl wadaag",
+      "StringValue": "hawl wadaag",
+      "NumericValue": 7,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "hawl wadaag"
+      ]
+    },
+    {
+      "CodeID": "code-156f94ee",
+      "CodeType": "Normal",
+      "DisplayText": "karaan",
+      "StringValue": "karaan",
+      "NumericValue": 8,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "karaan"
+      ]
+    },
+    {
+      "CodeID": "code-15b664b5",
+      "CodeType": "Normal",
+      "DisplayText": "kaxda",
+      "StringValue": "kaxda",
+      "NumericValue": 17,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kaxda"
+      ]
+    },
+    {
+      "CodeID": "code-22f2f7d6",
+      "CodeType": "Normal",
+      "DisplayText": "shangaani",
+      "StringValue": "shangaani",
+      "NumericValue": 9,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "shangaani"
+      ]
+    },
+    {
+      "CodeID": "code-ea1d62ae",
+      "CodeType": "Normal",
+      "DisplayText": "shibis",
+      "StringValue": "shibis",
+      "NumericValue": 10,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "shibis"
+      ]
+    },
+    {
+      "CodeID": "code-b425d5db",
+      "CodeType": "Normal",
+      "DisplayText": "waaberi",
+      "StringValue": "waaberi",
+      "NumericValue": 11,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "waaberi"
+      ]
+    },
+    {
+      "CodeID": "code-eb4fdeb3",
+      "CodeType": "Normal",
+      "DisplayText": "wadajir",
+      "StringValue": "wadajir",
+      "NumericValue": 12,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "wadajir"
+      ]
+    },
+    {
+      "CodeID": "code-818d857f",
+      "CodeType": "Normal",
+      "DisplayText": "wardhiigleey",
+      "StringValue": "wardhiigleey",
+      "NumericValue": 13,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "wardhiigleey"
+      ]
+    },
+    {
+      "CodeID": "code-d618fa3a",
+      "CodeType": "Normal",
+      "DisplayText": "xamar jaabjab",
+      "StringValue": "xamar jaabjab",
+      "NumericValue": 14,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "xamar jaabjab"
+      ]
+    },
+    {
+      "CodeID": "code-2e3cedff",
+      "CodeType": "Normal",
+      "DisplayText": "xamar weyne",
+      "StringValue": "xamar weyne",
+      "NumericValue": 15,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "xamar weyne"
+      ]
+    },
+    {
+      "CodeID": "code-d16d73ca",
+      "CodeType": "Normal",
+      "DisplayText": "yaaqshid",
+      "StringValue": "yaaqshid",
+      "NumericValue": 16,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "yaaqshid"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/demographics/recently_displaced.json
+++ b/code_schemes/demographics/recently_displaced.json
@@ -1,0 +1,211 @@
+{
+  "SchemeID": "Scheme-e1aa9330",
+  "Name": "Recently Displaced",
+  "Version": "0.0.0.4",
+  "Codes": [
+    {
+      "CodeID": "code-2b565901",
+      "CodeType": "Normal",
+      "DisplayText": "yes",
+      "NumericValue": 1,
+      "StringValue": "yes",
+      "Shortcut": "y",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "yes"
+      ]
+    },
+    {
+      "CodeID": "code-d67739e0",
+      "CodeType": "Normal",
+      "DisplayText": "no",
+      "Shortcut": "n",
+      "NumericValue": 2,
+      "StringValue": "no",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "no"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/demographics/somalia_district.json
+++ b/code_schemes/demographics/somalia_district.json
@@ -1,0 +1,1001 @@
+{
+  "SchemeID": "Scheme-5292e8fb",
+  "Name": "Somalia District",
+  "Version": "0.0.0.6",
+  "Codes": [
+    {
+      "CodeID": "code-acc06b14",
+      "CodeType": "Normal",
+      "DisplayText": "adan yabaal",
+      "StringValue": "adan yabaal",
+      "NumericValue": 1,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "adan yabaal"
+      ]
+    },
+    {
+      "CodeID": "code-99f80d95",
+      "CodeType": "Normal",
+      "DisplayText": "afgooye",
+      "StringValue": "afgooye",
+      "NumericValue": 2,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "afgooye"
+      ]
+    },
+    {
+      "CodeID": "code-a716e317",
+      "CodeType": "Normal",
+      "DisplayText": "afmadow",
+      "StringValue": "afmadow",
+      "NumericValue": 3,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "afmadow"
+      ]
+    },
+    {
+      "CodeID": "code-a6284186",
+      "CodeType": "Normal",
+      "DisplayText": "baardheere",
+      "StringValue": "baardheere",
+      "NumericValue": 4,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "baardheere"
+      ]
+    },
+    {
+      "CodeID": "code-eaf4bef5",
+      "CodeType": "Normal",
+      "DisplayText": "badhaadhe",
+      "StringValue": "badhaadhe",
+      "NumericValue": 5,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "badhaadhe"
+      ]
+    },
+    {
+      "CodeID": "code-208448a6",
+      "CodeType": "Normal",
+      "DisplayText": "baidoa",
+      "StringValue": "baidoa",
+      "NumericValue": 6,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "baidoa"
+      ]
+    },
+    {
+      "CodeID": "code-779a3d3f",
+      "CodeType": "Normal",
+      "DisplayText": "baki",
+      "StringValue": "baki",
+      "NumericValue": 7,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "baki"
+      ]
+    },
+    {
+      "CodeID": "code-36520d40",
+      "CodeType": "Normal",
+      "DisplayText": "balcad",
+      "StringValue": "balcad",
+      "NumericValue": 8,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "balcad"
+      ]
+    },
+    {
+      "CodeID": "code-78e2f093",
+      "CodeType": "Normal",
+      "DisplayText": "bandarbayla",
+      "StringValue": "bandarbayla",
+      "NumericValue": 9,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "bandarbayla"
+      ]
+    },
+    {
+      "CodeID": "code-d5431931",
+      "CodeType": "Normal",
+      "DisplayText": "baraawe",
+      "StringValue": "baraawe",
+      "NumericValue": 10,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "baraawe"
+      ]
+    },
+    {
+      "CodeID": "code-a408a571",
+      "CodeType": "Normal",
+      "DisplayText": "belet weyne",
+      "StringValue": "belet weyne",
+      "NumericValue": 11,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "belet weyne"
+      ]
+    },
+    {
+      "CodeID": "code-97060a6b",
+      "CodeType": "Normal",
+      "DisplayText": "belet xaawo",
+      "StringValue": "belet xaawo",
+      "NumericValue": 12,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "belet xaawo"
+      ]
+    },
+    {
+      "CodeID": "code-0fd51f04",
+      "CodeType": "Normal",
+      "DisplayText": "berbera",
+      "StringValue": "berbera",
+      "NumericValue": 13,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "berbera"
+      ]
+    },
+    {
+      "CodeID": "code-31269732",
+      "CodeType": "Normal",
+      "DisplayText": "borama",
+      "StringValue": "borama",
+      "NumericValue": 14,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "borama"
+      ]
+    },
+    {
+      "CodeID": "code-d65cb0c1",
+      "CodeType": "Normal",
+      "DisplayText": "bossaso",
+      "StringValue": "bossaso",
+      "NumericValue": 15,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "bossaso"
+      ]
+    },
+    {
+      "CodeID": "code-6018057d",
+      "CodeType": "Normal",
+      "DisplayText": "bu'aale",
+      "StringValue": "bu'aale",
+      "NumericValue": 16,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "bu'aale"
+      ]
+    },
+    {
+      "CodeID": "code-680f7c83",
+      "CodeType": "Normal",
+      "DisplayText": "bulo burto",
+      "StringValue": "bulo burto",
+      "NumericValue": 17,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "bulo burto"
+      ]
+    },
+    {
+      "CodeID": "code-ce068ef6",
+      "CodeType": "Normal",
+      "DisplayText": "burco",
+      "StringValue": "burco",
+      "NumericValue": 18,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "burco"
+      ]
+    },
+    {
+      "CodeID": "code-9a9fdf9f",
+      "CodeType": "Normal",
+      "DisplayText": "burtinle",
+      "StringValue": "burtinle",
+      "NumericValue": 19,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "burtinle"
+      ]
+    },
+    {
+      "CodeID": "code-253daee4",
+      "CodeType": "Normal",
+      "DisplayText": "buuhoodle",
+      "StringValue": "buuhoodle",
+      "NumericValue": 20,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "buuhoodle"
+      ]
+    },
+    {
+      "CodeID": "code-3ffd2257",
+      "CodeType": "Normal",
+      "DisplayText": "buur hakaba",
+      "StringValue": "buur hakaba",
+      "NumericValue": 21,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "buur hakaba"
+      ]
+    },
+    {
+      "CodeID": "code-a28e06ac",
+      "CodeType": "Normal",
+      "DisplayText": "cabudwaaq",
+      "StringValue": "cabudwaaq",
+      "NumericValue": 22,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "cabudwaaq"
+      ]
+    },
+    {
+      "CodeID": "code-ac4ddb4e",
+      "CodeType": "Normal",
+      "DisplayText": "cadaado",
+      "StringValue": "cadaado",
+      "NumericValue": 23,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "cadaado"
+      ]
+    },
+    {
+      "CodeID": "code-497158fa",
+      "CodeType": "Normal",
+      "DisplayText": "cadale",
+      "StringValue": "cadale",
+      "NumericValue": 24,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "cadale"
+      ]
+    },
+    {
+      "CodeID": "code-a1364b59",
+      "CodeType": "Normal",
+      "DisplayText": "caluula",
+      "StringValue": "caluula",
+      "NumericValue": 25,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "caluula"
+      ]
+    },
+    {
+      "CodeID": "code-72e08200",
+      "CodeType": "Normal",
+      "DisplayText": "caynabo",
+      "StringValue": "caynabo",
+      "NumericValue": 26,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "caynabo"
+      ]
+    },
+    {
+      "CodeID": "code-2d58a9b8",
+      "CodeType": "Normal",
+      "DisplayText": "ceel afweyn",
+      "StringValue": "ceel afweyn",
+      "NumericValue": 27,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "ceel afweyn"
+      ]
+    },
+    {
+      "CodeID": "code-1878985c",
+      "CodeType": "Normal",
+      "DisplayText": "ceel barde",
+      "StringValue": "ceel barde",
+      "NumericValue": 28,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "ceel barde"
+      ]
+    },
+    {
+      "CodeID": "code-2d35116a",
+      "CodeType": "Normal",
+      "DisplayText": "ceel buur",
+      "StringValue": "ceel buur",
+      "NumericValue": 29,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "ceel buur"
+      ]
+    },
+    {
+      "CodeID": "code-3ece35eb",
+      "CodeType": "Normal",
+      "DisplayText": "ceel dheer",
+      "StringValue": "ceel dheer",
+      "NumericValue": 30,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "ceel dheer"
+      ]
+    },
+    {
+      "CodeID": "code-aaf4d2e6",
+      "CodeType": "Normal",
+      "DisplayText": "ceel waaq",
+      "StringValue": "ceel waaq",
+      "NumericValue": 31,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "ceel waaq"
+      ]
+    },
+    {
+      "CodeID": "code-6b541d8e",
+      "CodeType": "Normal",
+      "DisplayText": "ceerigaabo",
+      "StringValue": "ceerigaabo",
+      "NumericValue": 32,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "ceerigaabo"
+      ]
+    },
+    {
+      "CodeID": "code-38821e5d",
+      "CodeType": "Normal",
+      "DisplayText": "dhuusamarreeb",
+      "StringValue": "dhuusamarreeb",
+      "NumericValue": 33,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "dhuusamarreeb"
+      ]
+    },
+    {
+      "CodeID": "code-9c11e9ce",
+      "CodeType": "Normal",
+      "DisplayText": "diinsoor",
+      "StringValue": "diinsoor",
+      "NumericValue": 34,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "diinsoor"
+      ]
+    },
+    {
+      "CodeID": "code-355a2ec6",
+      "CodeType": "Normal",
+      "DisplayText": "doolow",
+      "StringValue": "doolow",
+      "NumericValue": 35,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "doolow"
+      ]
+    },
+    {
+      "CodeID": "code-9a0af590",
+      "CodeType": "Normal",
+      "DisplayText": "eyl",
+      "StringValue": "eyl",
+      "NumericValue": 36,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "eyl"
+      ]
+    },
+    {
+      "CodeID": "code-4586b218",
+      "CodeType": "Normal",
+      "DisplayText": "gaalkacyo",
+      "StringValue": "gaalkacyo",
+      "NumericValue": 37,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "gaalkacyo"
+      ]
+    },
+    {
+      "CodeID": "code-7d1549a8",
+      "CodeType": "Normal",
+      "DisplayText": "galdogob",
+      "StringValue": "galdogob",
+      "NumericValue": 38,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "galdogob"
+      ]
+    },
+    {
+      "CodeID": "code-2006f966",
+      "CodeType": "Normal",
+      "DisplayText": "garbahaarey",
+      "StringValue": "garbahaarey",
+      "NumericValue": 39,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "garbahaarey"
+      ]
+    },
+    {
+      "CodeID": "code-fdb62e36",
+      "CodeType": "Normal",
+      "DisplayText": "garowe",
+      "StringValue": "garowe",
+      "NumericValue": 40,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "garowe"
+      ]
+    },
+    {
+      "CodeID": "code-0fdbac5a",
+      "CodeType": "Normal",
+      "DisplayText": "gebiley",
+      "StringValue": "gebiley",
+      "NumericValue": 41,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "gebiley"
+      ]
+    },
+    {
+      "CodeID": "code-6d47f6ed",
+      "CodeType": "Normal",
+      "DisplayText": "hargeysa",
+      "StringValue": "hargeysa",
+      "NumericValue": 42,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "hargeysa"
+      ]
+    },
+    {
+      "CodeID": "code-6f638555",
+      "CodeType": "Normal",
+      "DisplayText": "hobyo",
+      "StringValue": "hobyo",
+      "NumericValue": 43,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "hobyo"
+      ]
+    },
+    {
+      "CodeID": "code-d738bdb1",
+      "CodeType": "Normal",
+      "DisplayText": "iskushuban",
+      "StringValue": "iskushuban",
+      "NumericValue": 44,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "iskushuban"
+      ]
+    },
+    {
+      "CodeID": "code-9ba0cc74",
+      "CodeType": "Normal",
+      "DisplayText": "jalalaqsi",
+      "StringValue": "jalalaqsi",
+      "NumericValue": 45,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "jalalaqsi"
+      ]
+    },
+    {
+      "CodeID": "code-32df3582",
+      "CodeType": "Normal",
+      "DisplayText": "jamaame",
+      "StringValue": "jamaame",
+      "NumericValue": 46,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "jamaame"
+      ]
+    },
+    {
+      "CodeID": "code-35b251ad",
+      "CodeType": "Normal",
+      "DisplayText": "jariiban",
+      "StringValue": "jariiban",
+      "NumericValue": 47,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "jariiban"
+      ]
+    },
+    {
+      "CodeID": "code-8210ad81",
+      "CodeType": "Normal",
+      "DisplayText": "jilib",
+      "StringValue": "jilib",
+      "NumericValue": 48,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "jilib"
+      ]
+    },
+    {
+      "CodeID": "code-2b4462d4",
+      "CodeType": "Normal",
+      "DisplayText": "jowhar",
+      "StringValue": "jowhar",
+      "NumericValue": 49,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "jowhar"
+      ]
+    },
+    {
+      "CodeID": "code-6294f98f",
+      "CodeType": "Normal",
+      "DisplayText": "kismayo",
+      "StringValue": "kismayo",
+      "NumericValue": 50,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kismayo"
+      ]
+    },
+    {
+      "CodeID": "code-3b9ff423",
+      "CodeType": "Normal",
+      "DisplayText": "kurtunwaarey",
+      "StringValue": "kurtunwaarey",
+      "NumericValue": 51,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kurtunwaarey"
+      ]
+    },
+    {
+      "CodeID": "code-f66748d8",
+      "CodeType": "Normal",
+      "DisplayText": "laas caanood",
+      "StringValue": "laas caanood",
+      "NumericValue": 52,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "laas caanood"
+      ]
+    },
+    {
+      "CodeID": "code-bff850eb",
+      "CodeType": "Normal",
+      "DisplayText": "lasqooray",
+      "StringValue": "lasqooray",
+      "NumericValue": 53,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "lasqooray"
+      ]
+    },
+    {
+      "CodeID": "code-7dabd8d4",
+      "CodeType": "Normal",
+      "DisplayText": "lughaye",
+      "StringValue": "lughaye",
+      "NumericValue": 54,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "lughaye"
+      ]
+    },
+    {
+      "CodeID": "code-35009ee0",
+      "CodeType": "Normal",
+      "DisplayText": "luuq",
+      "StringValue": "luuq",
+      "NumericValue": 55,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "luuq"
+      ]
+    },
+    {
+      "CodeID": "code-a241e816",
+      "CodeType": "Normal",
+      "DisplayText": "marka",
+      "StringValue": "marka",
+      "NumericValue": 56,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "marka"
+      ]
+    },
+    {
+      "CodeID": "code-2e6192c8",
+      "CodeType": "Normal",
+      "DisplayText": "mogadishu",
+      "StringValue": "mogadishu",
+      "NumericValue": 57,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mogadishu"
+      ]
+    },
+    {
+      "CodeID": "code-b90949c4",
+      "CodeType": "Normal",
+      "DisplayText": "owdweyne",
+      "StringValue": "owdweyne",
+      "NumericValue": 58,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "owdweyne"
+      ]
+    },
+    {
+      "CodeID": "code-d729dbd8",
+      "CodeType": "Normal",
+      "DisplayText": "qandala",
+      "StringValue": "qandala",
+      "NumericValue": 59,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "qandala"
+      ]
+    },
+    {
+      "CodeID": "code-ea7d452b",
+      "CodeType": "Normal",
+      "DisplayText": "qansax dheere",
+      "StringValue": "qansax dheere",
+      "NumericValue": 60,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "qansax dheere"
+      ]
+    },
+    {
+      "CodeID": "code-28ad8e85",
+      "CodeType": "Normal",
+      "DisplayText": "qardho",
+      "StringValue": "qardho",
+      "NumericValue": 61,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "qardho"
+      ]
+    },
+    {
+      "CodeID": "code-91837fee",
+      "CodeType": "Normal",
+      "DisplayText": "qoryooley",
+      "StringValue": "qoryooley",
+      "NumericValue": 62,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "qoryooley"
+      ]
+    },
+    {
+      "CodeID": "code-bba91f81",
+      "CodeType": "Normal",
+      "DisplayText": "rab dhuure",
+      "StringValue": "rab dhuure",
+      "NumericValue": 63,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "rab dhuure"
+      ]
+    },
+    {
+      "CodeID": "code-84d55e34",
+      "CodeType": "Normal",
+      "DisplayText": "saakow",
+      "StringValue": "saakow",
+      "NumericValue": 64,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "saakow"
+      ]
+    },
+    {
+      "CodeID": "code-af8f7cc3",
+      "CodeType": "Normal",
+      "DisplayText": "sablaale",
+      "StringValue": "sablaale",
+      "NumericValue": 65,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "sablaale"
+      ]
+    },
+    {
+      "CodeID": "code-6e2a9fb5",
+      "CodeType": "Normal",
+      "DisplayText": "sheikh",
+      "StringValue": "sheikh",
+      "NumericValue": 66,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "sheikh"
+      ]
+    },
+    {
+      "CodeID": "code-5db026ee",
+      "CodeType": "Normal",
+      "DisplayText": "taleex",
+      "StringValue": "taleex",
+      "NumericValue": 67,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "taleex"
+      ]
+    },
+    {
+      "CodeID": "code-e3d43b38",
+      "CodeType": "Normal",
+      "DisplayText": "tayeeglow",
+      "StringValue": "tayeeglow",
+      "NumericValue": 68,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "tayeeglow"
+      ]
+    },
+    {
+      "CodeID": "code-d05f8e5a",
+      "CodeType": "Normal",
+      "DisplayText": "waajid",
+      "StringValue": "waajid",
+      "NumericValue": 69,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "waajid"
+      ]
+    },
+    {
+      "CodeID": "code-b706ce43",
+      "CodeType": "Normal",
+      "DisplayText": "wanla weyn",
+      "StringValue": "wanla weyn",
+      "NumericValue": 70,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "wanla weyn"
+      ]
+    },
+    {
+      "CodeID": "code-ca5bde30",
+      "CodeType": "Normal",
+      "DisplayText": "xarardheere",
+      "StringValue": "xarardheere",
+      "NumericValue": 71,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "xarardheere"
+      ]
+    },
+    {
+      "CodeID": "code-a0f5e712",
+      "CodeType": "Normal",
+      "DisplayText": "xudun",
+      "StringValue": "xudun",
+      "NumericValue": 72,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "xudun"
+      ]
+    },
+    {
+      "CodeID": "code-24fb7c50",
+      "CodeType": "Normal",
+      "DisplayText": "xudur",
+      "StringValue": "xudur",
+      "NumericValue": 73,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "xudur"
+      ]
+    },
+    {
+      "CodeID": "code-26d99b64",
+      "CodeType": "Normal",
+      "DisplayText": "zeylac",
+      "StringValue": "zeylac",
+      "NumericValue": 74,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "zeylac"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/demographics/somalia_region.json
+++ b/code_schemes/demographics/somalia_region.json
@@ -1,0 +1,385 @@
+{
+  "SchemeID": "Scheme-644e3296",
+  "Name": "Somalia Region",
+  "Version": "0.0.0.6",
+  "Codes": [
+    {
+      "CodeID": "code-8af5ec4f",
+      "CodeType": "Normal",
+      "DisplayText": "awdal",
+      "StringValue": "awdal",
+      "NumericValue": 1,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "awdal"
+      ]
+    },
+    {
+      "CodeID": "code-44c06c41",
+      "CodeType": "Normal",
+      "DisplayText": "bakool",
+      "StringValue": "bakool",
+      "NumericValue": 2,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "bakool"
+      ]
+    },
+    {
+      "CodeID": "code-74bcbe18",
+      "CodeType": "Normal",
+      "DisplayText": "banadir",
+      "StringValue": "banadir",
+      "NumericValue": 3,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "banadir"
+      ]
+    },
+    {
+      "CodeID": "code-49607fe4",
+      "CodeType": "Normal",
+      "DisplayText": "bari",
+      "StringValue": "bari",
+      "NumericValue": 4,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "bari"
+      ]
+    },
+    {
+      "CodeID": "code-2870c0ee",
+      "CodeType": "Normal",
+      "DisplayText": "bay",
+      "StringValue": "bay",
+      "NumericValue": 5,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "bay"
+      ]
+    },
+    {
+      "CodeID": "code-53697dd0",
+      "CodeType": "Normal",
+      "DisplayText": "galgaduud",
+      "StringValue": "galgaduud",
+      "NumericValue": 6,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "galgaduud"
+      ]
+    },
+    {
+      "CodeID": "code-000c5297",
+      "CodeType": "Normal",
+      "DisplayText": "gedo",
+      "StringValue": "gedo",
+      "NumericValue": 7,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "gedo"
+      ]
+    },
+    {
+      "CodeID": "code-12d31795",
+      "CodeType": "Normal",
+      "DisplayText": "hiraan",
+      "StringValue": "hiraan",
+      "NumericValue": 8,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "hiraan"
+      ]
+    },
+    {
+      "CodeID": "code-81b18fce",
+      "CodeType": "Normal",
+      "DisplayText": "lower juba",
+      "StringValue": "lower juba",
+      "NumericValue": 9,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "lower juba"
+      ]
+    },
+    {
+      "CodeID": "code-5eaa3b3e",
+      "CodeType": "Normal",
+      "DisplayText": "lower shabelle",
+      "StringValue": "lower shabelle",
+      "NumericValue": 10,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "lower shabelle"
+      ]
+    },
+    {
+      "CodeID": "code-fbac6497",
+      "CodeType": "Normal",
+      "DisplayText": "middle juba",
+      "StringValue": "middle juba",
+      "NumericValue": 11,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "middle juba"
+      ]
+    },
+    {
+      "CodeID": "code-74428246",
+      "CodeType": "Normal",
+      "DisplayText": "middle shabelle",
+      "StringValue": "middle shabelle",
+      "NumericValue": 12,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "middle shabelle"
+      ]
+    },
+    {
+      "CodeID": "code-0c909391",
+      "CodeType": "Normal",
+      "DisplayText": "mudug",
+      "StringValue": "mudug",
+      "NumericValue": 13,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "mudug"
+      ]
+    },
+    {
+      "CodeID": "code-1b592fef",
+      "CodeType": "Normal",
+      "DisplayText": "nugaal",
+      "StringValue": "nugaal",
+      "NumericValue": 14,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "nugaal"
+      ]
+    },
+    {
+      "CodeID": "code-e5f63151",
+      "CodeType": "Normal",
+      "DisplayText": "sanaag",
+      "StringValue": "sanaag",
+      "NumericValue": 15,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "sanaag"
+      ]
+    },
+    {
+      "CodeID": "code-b15551e9",
+      "CodeType": "Normal",
+      "DisplayText": "sool",
+      "StringValue": "sool",
+      "NumericValue": 16,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "sool"
+      ]
+    },
+    {
+      "CodeID": "code-cf0e0f33",
+      "CodeType": "Normal",
+      "DisplayText": "togdheer",
+      "StringValue": "togdheer",
+      "NumericValue": 17,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "togdheer"
+      ]
+    },
+    {
+      "CodeID": "code-98931bb8",
+      "CodeType": "Normal",
+      "DisplayText": "woqooyi galbeed",
+      "StringValue": "woqooyi galbeed",
+      "NumericValue": 18,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "woqooyi galbeed"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/demographics/somalia_state.json
+++ b/code_schemes/demographics/somalia_state.json
@@ -1,0 +1,264 @@
+{
+  "SchemeID": "Scheme-a390e6ce",
+  "Name": "Somalia State",
+  "Version": "0.0.0.6",
+  "Codes": [
+    {
+      "CodeID": "code-3951a76e",
+      "CodeType": "Normal",
+      "DisplayText": "banadir",
+      "StringValue": "banadir",
+      "NumericValue": 1,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "banadir"
+      ]
+    },
+    {
+      "CodeID": "code-42498bd0",
+      "CodeType": "Normal",
+      "DisplayText": "galmudug",
+      "StringValue": "galmudug",
+      "NumericValue": 2,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "galmudug"
+      ]
+    },
+    {
+      "CodeID": "code-79e2b000",
+      "CodeType": "Normal",
+      "DisplayText": "hir-shabelle",
+      "StringValue": "hir-shabelle",
+      "NumericValue": 3,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "hir-shabelle"
+      ]
+    },
+    {
+      "CodeID": "code-0a1aaafb",
+      "CodeType": "Normal",
+      "DisplayText": "jubbaland",
+      "StringValue": "jubbaland",
+      "NumericValue": 4,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "jubbaland"
+      ]
+    },
+    {
+      "CodeID": "code-8ba54648",
+      "CodeType": "Normal",
+      "DisplayText": "puntland",
+      "StringValue": "puntland",
+      "NumericValue": 5,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "puntland"
+      ]
+    },
+    {
+      "CodeID": "code-3e70a2b5",
+      "CodeType": "Normal",
+      "DisplayText": "somaliland",
+      "StringValue": "somaliland",
+      "NumericValue": 6,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "somaliland"
+      ]
+    },
+    {
+      "CodeID": "code-1cb9c226",
+      "CodeType": "Normal",
+      "DisplayText": "south west state",
+      "StringValue": "south west state",
+      "NumericValue": 7,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "south west state"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/demographics/somalia_zone.json
+++ b/code_schemes/demographics/somalia_zone.json
@@ -1,0 +1,220 @@
+{
+  "SchemeID": "Scheme-b8ce44fb",
+  "Name": "Somalia Zone",
+  "Version": "0.0.0.6",
+  "Codes": [
+    {
+      "CodeID": "code-af199806",
+      "CodeType": "Normal",
+      "DisplayText": "nez",
+      "StringValue": "nez",
+      "NumericValue": 1,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "nez"
+      ]
+    },
+    {
+      "CodeID": "code-af3d9e5b",
+      "CodeType": "Normal",
+      "DisplayText": "nwz",
+      "StringValue": "nwz",
+      "NumericValue": 2,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "nwz"
+      ]
+    },
+    {
+      "CodeID": "code-dc3483fa",
+      "CodeType": "Normal",
+      "DisplayText": "scz",
+      "StringValue": "scz",
+      "NumericValue": 3,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "scz"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/rqas/eu_pcve/eu_pcve_s01_follow_up.json
+++ b/code_schemes/rqas/eu_pcve/eu_pcve_s01_follow_up.json
@@ -1,0 +1,235 @@
+{
+  "SchemeID": "Scheme-c656b67f",
+  "Name": "S01 Follow-Up",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-bcfc2fd1",
+      "CodeType": "Normal",
+      "DisplayText": "delays in election",
+      "NumericValue": 1,
+      "StringValue": "delays_in_election",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-b0c254da",
+      "CodeType": "Normal",
+      "DisplayText": "covid 19 and elections have diverted attention from pcve/ve",
+      "NumericValue": 2,
+      "StringValue": "covid_19_and_elections_have_diverted_attention_from_pcve_ve",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-129ecdec",
+      "CodeType": "Normal",
+      "DisplayText": "community unity and cooperation",
+      "NumericValue": 3,
+      "StringValue": "community_unity_and_cooperation",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-f1c35c45",
+      "CodeType": "Normal",
+      "DisplayText": "general impact of covid 19",
+      "NumericValue": 4,
+      "StringValue": "general_impact_of_covid_19",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-244ac3ea",
+      "CodeType": "Normal",
+      "DisplayText": "prevention against covid 19",
+      "NumericValue": 5,
+      "StringValue": "prevention_against_covid_19",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-f9425839",
+      "CodeType": "Normal",
+      "DisplayText": "other theme",
+      "NumericValue": 6,
+      "StringValue": "other_theme",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/rqas/eu_pcve/eu_pcve_s01e01.json
+++ b/code_schemes/rqas/eu_pcve/eu_pcve_s01e01.json
@@ -1,0 +1,259 @@
+{
+  "SchemeID": "Scheme-624e54af",
+  "Name": "RQA S01E01",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-785a37e9",
+      "CodeType": "Normal",
+      "DisplayText": "partial support for extremism",
+      "NumericValue": 1,
+      "StringValue": "partial_support_for_extremism",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-db77cff0",
+      "CodeType": "Normal",
+      "DisplayText": "extremism is wrong and bad",
+      "NumericValue": 2,
+      "StringValue": "extremism_is_wrong_and_bad",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-a8610f35",
+      "CodeType": "Normal",
+      "DisplayText": "extremism causes fear & insecurity",
+      "NumericValue": 3,
+      "StringValue": "extremism_causes_fear_and_insecurity",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-d7785739",
+      "CodeType": "Normal",
+      "DisplayText": "extremism is against the religious teachings",
+      "NumericValue": 4,
+      "StringValue": "extremism_is_against_the_religious_teachings",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-083c8e62",
+      "CodeType": "Normal",
+      "DisplayText": "need for awareness creation",
+      "NumericValue": 5,
+      "StringValue": "need_for_awareness_creation",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-7e86c02c",
+      "CodeType": "Normal",
+      "DisplayText": "violation against human rights/dignity",
+      "NumericValue": 6,
+      "StringValue": "violation_against_human_rights_or_dignity",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-3b7b2788",
+      "CodeType": "Normal",
+      "DisplayText": "extremism is caused by injustice within the community",
+      "NumericValue": 7,
+      "StringValue": "extremism_is_caused_by_injustice_within_the_community",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-3bf58114",
+      "CodeType": "Normal",
+      "DisplayText": "fight against extremism",
+      "NumericValue": 8,
+      "StringValue": "fight_against_extremism",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-7063a3fd",
+      "CodeType": "Normal",
+      "DisplayText": "other theme",
+      "NumericValue": 9,
+      "StringValue": "other_theme",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/rqas/eu_pcve/eu_pcve_s01e02.json
+++ b/code_schemes/rqas/eu_pcve/eu_pcve_s01e02.json
@@ -1,0 +1,251 @@
+{
+  "SchemeID": "Scheme-6392b421",
+  "Name": "RQA S01E02",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-3d2ccd1e",
+      "CodeType": "Normal",
+      "DisplayText": "injustice",
+      "NumericValue": 1,
+      "StringValue": "injustice",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-7f446f90",
+      "CodeType": "Normal",
+      "DisplayText": "lack of cooperation & action",
+      "NumericValue": 2,
+      "StringValue": "lack_of_cooperation_and_action",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-cdbe9754",
+      "CodeType": "Normal",
+      "DisplayText": "ignorance/misinterpretation of the religion",
+      "NumericValue": 3,
+      "StringValue": "ignorance_or_misinterpretation_of_the_religion",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-b572ebd2",
+      "CodeType": "Normal",
+      "DisplayText": "lack of good governance",
+      "NumericValue": 4,
+      "StringValue": "lack_of_good_governance",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-d0d8d8b5",
+      "CodeType": "Normal",
+      "DisplayText": "lack of awareness",
+      "NumericValue": 5,
+      "StringValue": "lack_of_awareness",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-6d6c0247",
+      "CodeType": "Normal",
+      "DisplayText": "unemployment",
+      "NumericValue": 6,
+      "StringValue": "unemployment",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-63d9909d",
+      "CodeType": "Normal",
+      "DisplayText": "clannism and conflict",
+      "NumericValue": 7,
+      "StringValue": "clannism_and_conflict",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-3b2e47a6",
+      "CodeType": "Normal",
+      "DisplayText": "other theme",
+      "NumericValue": 8,
+      "StringValue": "other_theme",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/rqas/eu_pcve/eu_pcve_s01e03.json
+++ b/code_schemes/rqas/eu_pcve/eu_pcve_s01e03.json
@@ -1,0 +1,251 @@
+{
+  "SchemeID": "Scheme-8a71eafb",
+  "Name": "RQA S01E03",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-cbfe2766",
+      "CodeType": "Normal",
+      "DisplayText": "educate the community on extremism",
+      "NumericValue": 1,
+      "StringValue": "educate_the_community_on_extremism",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-ff7a8935",
+      "CodeType": "Normal",
+      "DisplayText": "follow and learn the teachings of islam",
+      "NumericValue": 2,
+      "StringValue": "follow_and_learn_the_teachings_of_islam",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-36b1e1a1",
+      "CodeType": "Normal",
+      "DisplayText": "stop clannism",
+      "NumericValue": 3,
+      "StringValue": "stop_clannism",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-3c00911f",
+      "CodeType": "Normal",
+      "DisplayText": "unity and collaboration between the community",
+      "NumericValue": 4,
+      "StringValue": "unity_and_collaboration_between_the_community",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-504c2552",
+      "CodeType": "Normal",
+      "DisplayText": "job creation for youth",
+      "NumericValue": 5,
+      "StringValue": "job_creation_for_youth",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-6474fbc1",
+      "CodeType": "Normal",
+      "DisplayText": "community to work with the government",
+      "NumericValue": 6,
+      "StringValue": "community_to_work_with_the_government",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-c238d27d",
+      "CodeType": "Normal",
+      "DisplayText": "stay away from or stop extremism",
+      "NumericValue": 7,
+      "StringValue": "stay_away_from_or_stop_extremism",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-063a29d3",
+      "CodeType": "Normal",
+      "DisplayText": "other theme",
+      "NumericValue": 8,
+      "StringValue": "other_theme",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/rqas/eu_pcve/eu_pcve_s01e04.json
+++ b/code_schemes/rqas/eu_pcve/eu_pcve_s01e04.json
@@ -1,0 +1,235 @@
+{
+  "SchemeID": "Scheme-f739f376",
+  "Name": "RQA S01E04",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-de4617c3",
+      "CodeType": "Normal",
+      "DisplayText": "follow the teachings of islam",
+      "NumericValue": 1,
+      "StringValue": "follow_the_teachings_of_islam",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-7e5602ee",
+      "CodeType": "Normal",
+      "DisplayText": "create awareness for the community",
+      "NumericValue": 2,
+      "StringValue": "create_awareness_for_the_community",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-9dc193eb",
+      "CodeType": "Normal",
+      "DisplayText": "provide security for the community",
+      "NumericValue": 3,
+      "StringValue": "provide_security_for_the_community",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-e2c768cc",
+      "CodeType": "Normal",
+      "DisplayText": "community collaboration and unity",
+      "NumericValue": 4,
+      "StringValue": "community_collaboration_and_unity",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-12fbb0ce",
+      "CodeType": "Normal",
+      "DisplayText": "good governance",
+      "NumericValue": 5,
+      "StringValue": "good_governance",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-ae88524e",
+      "CodeType": "Normal",
+      "DisplayText": "other theme",
+      "NumericValue": 6,
+      "StringValue": "other_theme",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/rqas/eu_pcve/eu_pcve_s01e05.json
+++ b/code_schemes/rqas/eu_pcve/eu_pcve_s01e05.json
@@ -1,0 +1,235 @@
+{
+  "SchemeID": "Scheme-09d87863",
+  "Name": "RQA S01E05",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-ed55f85e",
+      "CodeType": "Normal",
+      "DisplayText": "sensitization and awareness creation",
+      "NumericValue": 1,
+      "StringValue": "sensitization_and_awareness_creation",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-71138f5b",
+      "CodeType": "Normal",
+      "DisplayText": "community unity and cooperation",
+      "NumericValue": 2,
+      "StringValue": "community_unity_and_cooperation",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-c5633725",
+      "CodeType": "Normal",
+      "DisplayText": "cooperation with the government",
+      "NumericValue": 3,
+      "StringValue": "cooperation_with_the_government",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-daa98249",
+      "CodeType": "Normal",
+      "DisplayText": "through religion",
+      "NumericValue": 4,
+      "StringValue": "through_religion",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-a62f3766",
+      "CodeType": "Normal",
+      "DisplayText": "fair and just administration",
+      "NumericValue": 5,
+      "StringValue": "fair_and_just_administration",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-e1697b6c",
+      "CodeType": "Normal",
+      "DisplayText": "other theme",
+      "NumericValue": 6,
+      "StringValue": "other_theme",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/rqas/eu_pcve/eu_pcve_s01e06.json
+++ b/code_schemes/rqas/eu_pcve/eu_pcve_s01e06.json
@@ -1,0 +1,251 @@
+{
+  "SchemeID": "Scheme-85fe9b19",
+  "Name": "RQA S01E06",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-402a3dea",
+      "CodeType": "Normal",
+      "DisplayText": "promote islamic practice",
+      "NumericValue": 1,
+      "StringValue": "promote_islamic_practice",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-526d50f4",
+      "CodeType": "Normal",
+      "DisplayText": "community unity and cooperation",
+      "NumericValue": 2,
+      "StringValue": "community_unity_and_cooperation",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-7546a74d",
+      "CodeType": "Normal",
+      "DisplayText": "government to strengthen peace & security",
+      "NumericValue": 3,
+      "StringValue": "government_to_strengthen_peace_&_security",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-eb3a47a0",
+      "CodeType": "Normal",
+      "DisplayText": "cooperation between the government and the community",
+      "NumericValue": 4,
+      "StringValue": "cooperation_between_the_government_and_the_community",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-64ae55dc",
+      "CodeType": "Normal",
+      "DisplayText": "government to provide support for the community",
+      "NumericValue": 5,
+      "StringValue": "government_to_provide_support_for_the_community",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-6003a6ef",
+      "CodeType": "Normal",
+      "DisplayText": "fair and just administration",
+      "NumericValue": 6,
+      "StringValue": "fair_and_just_administration",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-b30078d4",
+      "CodeType": "Normal",
+      "DisplayText": "create awareness on extremism",
+      "NumericValue": 7,
+      "StringValue": "create_awareness_on_extremism",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-fc35e82a",
+      "CodeType": "Normal",
+      "DisplayText": "other theme",
+      "NumericValue": 8,
+      "StringValue": "other_theme",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "NumericValue": -100140,
+      "StringValue": "impact",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-O-7ce0d2a7",
+      "CodeType": "Meta",
+      "MetaCode": "other",
+      "DisplayText": "meta: other",
+      "NumericValue": -100110,
+      "StringValue": "other",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/ws_correct_dataset.json
+++ b/code_schemes/ws_correct_dataset.json
@@ -1,0 +1,838 @@
+{
+  "SchemeID": "Scheme-fffffc6e",
+  "Name": "WS - Correct Dataset",
+  "Version": "0.0.0.7",
+  "Codes": [
+    {
+      "CodeID": "code-652137c5",
+      "CodeType": "Normal",
+      "DisplayText": "EU-PCVE s01e01",
+      "StringValue": "eu_pcve_s01e01",
+      "NumericValue": 68,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "eu pcve s01e01"
+      ]
+    },
+    {
+      "CodeID": "code-502d5a1e",
+      "CodeType": "Normal",
+      "DisplayText": "EU-PCVE s01e02",
+      "StringValue": "eu_pcve_s01e02",
+      "NumericValue": 69,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "eu pcve s01e02"
+      ]
+    },
+    {
+      "CodeID": "code-774bbb53",
+      "CodeType": "Normal",
+      "DisplayText": "EU-PCVE s01e03",
+      "StringValue": "eu_pcve_s01e03",
+      "NumericValue": 70,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "eu pcve s01e03"
+      ]
+    },
+    {
+      "CodeID": "code-50e67f9d",
+      "CodeType": "Normal",
+      "DisplayText": "EU-PCVE s01e04",
+      "StringValue": "eu_pcve_s01e04",
+      "NumericValue": 71,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "eu pcve s01e04"
+      ]
+    },
+    {
+      "CodeID": "code-6d0b17fe",
+      "CodeType": "Normal",
+      "DisplayText": "EU-PCVE s01e05",
+      "StringValue": "eu_pcve_s01e05",
+      "NumericValue": 72,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "eu pcve s01e05"
+      ]
+    },
+    {
+      "CodeID": "code-292e88df",
+      "CodeType": "Normal",
+      "DisplayText": "EU-PCVE s01e06",
+      "StringValue": "eu_pcve_s01e06",
+      "NumericValue": 73,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "eu pcve s01e06"
+      ]
+    },
+    {
+      "CodeID": "code-c4e343c3",
+      "CodeType": "Normal",
+      "DisplayText": "EU-PCVE s01 follow-up",
+      "StringValue": "eu_pcve_s01_follow_up",
+      "NumericValue": 74,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "eu pcve s01 follow-up"
+      ]
+    },
+    {
+      "CodeID": "code-70ac05ab",
+      "CodeType": "Normal",
+      "DisplayText": "age",
+      "StringValue": "age",
+      "NumericValue": 1,
+      "VisibleInCoda": true,
+      "MatchValues":  [
+        "age"
+      ]
+    },
+    {
+      "CodeID": "code-6774cedd",
+      "CodeType": "Normal",
+      "DisplayText": "gender",
+      "StringValue": "gender",
+      "NumericValue": 2,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "gender"
+      ]
+    },
+    {
+      "CodeID": "code-dda6e4b4",
+      "CodeType": "Normal",
+      "DisplayText": "location",
+      "StringValue": "location",
+      "NumericValue": 3,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "location"
+      ]
+    },
+    {
+      "CodeID": "code-c2ef3b7f",
+      "CodeType": "Normal",
+      "DisplayText": "recently displaced",
+      "StringValue": "recently displaced",
+      "NumericValue": 4,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "recently displaced"
+      ]
+    },
+    {
+      "CodeID": "code-cd9eeed9",
+      "CodeType": "Normal",
+      "DisplayText": "in idp camp",
+      "StringValue": "in idp camp",
+      "NumericValue": 5,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "in idp camp"
+      ]
+    },
+    {
+      "CodeID": "code-e053ab04",
+      "CodeType": "Normal",
+      "DisplayText": "livelihood",
+      "StringValue": "livelihood",
+      "NumericValue": 41,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "livelihood"
+      ]
+    },
+    {
+      "CodeID": "code-3e722885",
+      "CodeType": "Normal",
+      "DisplayText": "children in school",
+      "StringValue": "children_in_school",
+      "NumericValue": 54,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "children in school"
+      ]
+    },
+    {
+      "CodeID": "code-87ec1cb8",
+      "CodeType": "Normal",
+      "DisplayText": "household language",
+      "StringValue": "household language",
+      "NumericValue": 6,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "hh language",
+        "household language"
+      ]
+    },
+    {
+      "CodeID": "code-9bd0f2b1",
+      "CodeType": "Normal",
+      "DisplayText": "s01e01",
+      "StringValue": "s01e01",
+      "NumericValue": 7,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s01e01"
+      ]
+    },
+    {
+      "CodeID": "code-9a5f15d6",
+      "CodeType": "Normal",
+      "DisplayText": "s01e02",
+      "StringValue": "s01e02",
+      "NumericValue": 8,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s01e02"
+      ]
+    },
+    {
+      "CodeID": "code-e8621530",
+      "CodeType": "Normal",
+      "DisplayText": "s01e03",
+      "StringValue": "s01e03",
+      "NumericValue": 9,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s01e03"
+      ]
+    },
+    {
+      "CodeID": "code-f7a875ee",
+      "CodeType": "Normal",
+      "DisplayText": "s01e04",
+      "StringValue": "s01e04",
+      "NumericValue": 10,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s01e04"
+      ]
+    },
+    {
+      "CodeID": "code-4dc91858",
+      "CodeType": "Normal",
+      "DisplayText": "s02e01",
+      "StringValue": "s02e01",
+      "NumericValue": 11,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s02e01"
+      ]
+    },
+    {
+      "CodeID": "code-93ae8d7f",
+      "CodeType": "Normal",
+      "DisplayText": "s02e02",
+      "StringValue": "s02e02",
+      "NumericValue": 12,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s02e02"
+      ]
+    },
+    {
+      "CodeID": "code-d321aaf7",
+      "CodeType": "Normal",
+      "DisplayText": "s02e03",
+      "StringValue": "s02e03",
+      "NumericValue": 13,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s02e03"
+      ]
+    },
+    {
+      "CodeID": "code-adc56730",
+      "CodeType": "Normal",
+      "DisplayText": "s02e04",
+      "StringValue": "s02e04",
+      "NumericValue": 14,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s02e04"
+      ]
+    },
+    {
+      "CodeID": "code-f216169d",
+      "CodeType": "Normal",
+      "DisplayText": "s02e05",
+      "StringValue": "s02e05",
+      "NumericValue": 15,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s02e05"
+      ]
+    },
+    {
+      "CodeID": "code-015a26ae",
+      "CodeType": "Normal",
+      "DisplayText": "s02e06",
+      "StringValue": "s02e06",
+      "NumericValue": 16,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s02e06"
+      ]
+    },
+    {
+      "CodeID": "code-c88d935a",
+      "CodeType": "Normal",
+      "DisplayText": "s03e01 bossaso",
+      "StringValue": "s03e01 bossaso",
+      "NumericValue": 17,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s03e01 bossaso"
+      ]
+    },
+    {
+      "CodeID": "code-877c8799",
+      "CodeType": "Normal",
+      "DisplayText": "s03e02 bossaso",
+      "StringValue": "s03e02 bossaso",
+      "NumericValue": 18,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s03e02 bossaso"
+      ]
+    },
+    {
+      "CodeID": "code-d32e8d97",
+      "CodeType": "Normal",
+      "DisplayText": "s03e03 bossaso",
+      "StringValue": "s03e03 bossaso",
+      "NumericValue": 19,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s03e03 bossaso"
+      ]
+    },
+    {
+      "CodeID": "code-d8f2ee69",
+      "CodeType": "Normal",
+      "DisplayText": "s03e04 bossaso",
+      "StringValue": "s03e04 bossaso",
+      "NumericValue": 20,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s03e04 bossaso"
+      ]
+    },
+    {
+      "CodeID": "code-2c048169",
+      "CodeType": "Normal",
+      "DisplayText": "s03e01 baidoa",
+      "StringValue": "s03e01 baidoa",
+      "NumericValue": 21,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s03e01 baidoa"
+      ]
+    },
+    {
+      "CodeID": "code-9036fd02",
+      "CodeType": "Normal",
+      "DisplayText": "s03e02 baidoa",
+      "StringValue": "s03e02 baidoa",
+      "NumericValue": 22,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s03e02 baidoa"
+      ]
+    },
+    {
+      "CodeID": "code-e7285811",
+      "CodeType": "Normal",
+      "DisplayText": "s03e03 baidoa",
+      "StringValue": "s03e03 baidoa",
+      "NumericValue": 23,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s03e03 baidoa"
+      ]
+    },
+    {
+      "CodeID": "code-15bb27cc",
+      "CodeType": "Normal",
+      "DisplayText": "s03e04 baidoa",
+      "StringValue": "s03e04 baidoa",
+      "NumericValue": 24,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s03e04 baidoa"
+      ]
+    },
+    {
+      "CodeID": "code-ec61083c",
+      "CodeType": "Normal",
+      "DisplayText": "s04e01",
+      "StringValue": "s04e01",
+      "NumericValue": 25,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s04e01"
+      ]
+    },
+    {
+      "CodeID": "code-097dbcfa",
+      "CodeType": "Normal",
+      "DisplayText": "s04e02",
+      "StringValue": "s04e02",
+      "NumericValue": 26,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s04e02"
+      ]
+    },
+    {
+      "CodeID": "code-09727857",
+      "CodeType": "Normal",
+      "DisplayText": "s05e01",
+      "StringValue": "s05e01",
+      "NumericValue": 29,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s05e01"
+      ]
+    },
+    {
+      "CodeID": "code-95db9a15",
+      "CodeType": "Normal",
+      "DisplayText": "s06e01",
+      "StringValue": "s06e01",
+      "NumericValue": 32,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s06e01"
+      ]
+    },
+    {
+      "CodeID": "code-0da948eb",
+      "CodeType": "Normal",
+      "DisplayText": "s06e02",
+      "StringValue": "s06e02",
+      "NumericValue": 33,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s06e02"
+      ]
+    },
+    {
+      "CodeID": "code-57f0b34a",
+      "CodeType": "Normal",
+      "DisplayText": "s07e01",
+      "StringValue": "s07e01",
+      "NumericValue": 34,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s07e01"
+      ]
+    },
+    {
+      "CodeID": "code-1ccdaa25",
+      "CodeType": "Normal",
+      "DisplayText": "s07e02",
+      "StringValue": "s07e02",
+      "NumericValue": 35,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s07e02"
+      ]
+    },
+    {
+      "CodeID": "code-9d20320f",
+      "CodeType": "Normal",
+      "DisplayText": "s07e03",
+      "StringValue": "s07e03",
+      "NumericValue": 36,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s07e03"
+      ]
+    },
+    {
+      "CodeID": "code-4d50ef28",
+      "CodeType": "Normal",
+      "DisplayText": "s08e01",
+      "StringValue": "s08e01",
+      "NumericValue": 38,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s08e01"
+      ]
+    },
+    {
+      "CodeID": "code-3c33d7fb",
+      "CodeType": "Normal",
+      "DisplayText": "s08e02",
+      "StringValue": "s08e02",
+      "NumericValue": 39,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s08e02"
+      ]
+    },
+    {
+      "CodeID": "code-42a7b651",
+      "CodeType": "Normal",
+      "DisplayText": "s08e03",
+      "StringValue": "s08e03",
+      "NumericValue": 40,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s08e03"
+      ]
+    },
+    {
+      "CodeID": "code-236eaee0",
+      "CodeType": "Normal",
+      "DisplayText": "s08e03 break",
+      "StringValue": "s08e03_break",
+      "NumericValue": 51,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s08e03_break"
+      ]
+    },
+    {
+      "CodeID": "code-050049c8",
+      "CodeType": "Normal",
+      "DisplayText": "s08e04",
+      "StringValue": "s08e04",
+      "NumericValue": 63,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s08e04"
+      ]
+    },
+    {
+      "CodeID": "code-262fa0fc",
+      "CodeType": "Normal",
+      "DisplayText": "s08e05",
+      "StringValue": "s08e05",
+      "NumericValue": 64,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s08e05"
+      ]
+    },
+    {
+      "CodeID": "code-c9115c69",
+      "CodeType": "Normal",
+      "DisplayText": "s08e06",
+      "StringValue": "s08e06",
+      "NumericValue": 65,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s08e06"
+      ]
+    },
+    {
+      "CodeID": "code-de134fc1",
+      "CodeType": "Normal",
+      "DisplayText": "have voice",
+      "StringValue": "have_voice",
+      "NumericValue": 27,
+      "VisibleInCoda": false,
+      "MatchValues": [
+        "have voice"
+      ]
+    },
+    {
+      "CodeID": "code-82af0326",
+      "CodeType": "Normal",
+      "DisplayText": "suggestions",
+      "StringValue": "suggestions",
+      "NumericValue": 28,
+      "VisibleInCoda": false,
+      "MatchValues": [
+        "suggestions"
+      ]
+    },
+    {
+      "CodeID": "code-ce0576ca",
+      "CodeType": "Normal",
+      "DisplayText": "responsible",
+      "StringValue": "responsible",
+      "NumericValue": 30,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "responsible"
+      ]
+    },
+    {
+      "CodeID": "code-c2cd8420",
+      "CodeType": "Normal",
+      "DisplayText": "solve problems",
+      "StringValue": "solve_problems",
+      "NumericValue": 31,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "solve problems"
+      ]
+    },
+    {
+      "CodeID": "code-c2963f98",
+      "CodeType": "Normal",
+      "DisplayText": "s07 government priority",
+      "StringValue": "s07_government_priority",
+      "NumericValue": 37,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s07 government priority"
+      ]
+    },
+    {
+      "CodeID": "code-076e22f0",
+      "CodeType": "Normal",
+      "DisplayText": "s09e01",
+      "StringValue": "s09e01",
+      "NumericValue": 42,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s09e01"
+      ]
+    },
+    {
+      "CodeID": "code-76017ab2",
+      "CodeType": "Normal",
+      "DisplayText": "s09e02",
+      "StringValue": "s09e02",
+      "NumericValue": 43,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s09e02"
+      ]
+    },
+    {
+      "CodeID": "code-04413b79",
+      "CodeType": "Normal",
+      "DisplayText": "s09e03",
+      "StringValue": "s09e03",
+      "NumericValue": 44,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s09e03"
+      ]
+    },
+    {
+      "CodeID": "code-1fe18580",
+      "CodeType": "Normal",
+      "DisplayText": "s09e03 break",
+      "StringValue": "s09e03_break",
+      "NumericValue": 45,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s09e03 break"
+      ]
+    },
+    {
+      "CodeID": "code-0b1cce35",
+      "CodeType": "Normal",
+      "DisplayText": "s09e04",
+      "StringValue": "s09e04",
+      "NumericValue": 46,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s09e04"
+      ]
+    },
+    {
+      "CodeID": "code-ada9931f",
+      "CodeType": "Normal",
+      "DisplayText": "s09e05",
+      "StringValue": "s09e05",
+      "NumericValue": 47,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s09e05"
+      ]
+    },
+    {
+      "CodeID": "code-5e288e86",
+      "CodeType": "Normal",
+      "DisplayText": "s09e06",
+      "StringValue": "s09e06",
+      "NumericValue": 48,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s09e06"
+      ]
+    },
+    {
+      "CodeID": "code-1fc8c37a",
+      "CodeType": "Normal",
+      "DisplayText": "s09e07",
+      "StringValue": "s09e07",
+      "NumericValue": 49,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s09e07"
+      ]
+    },
+    {
+      "CodeID": "code-44794930",
+      "CodeType": "Normal",
+      "DisplayText": "s09e08",
+      "StringValue": "s09e08",
+      "NumericValue": 50,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s09e08"
+      ]
+    },
+    {
+      "CodeID": "code-263a62e8",
+      "CodeType": "Normal",
+      "DisplayText": "s10e01",
+      "StringValue": "s10e01",
+      "NumericValue": 52,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s10e01"
+      ]
+    },
+    {
+      "CodeID": "code-96be0028",
+      "CodeType": "Normal",
+      "DisplayText": "s10e02",
+      "StringValue": "s10e02",
+      "NumericValue": 53,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s10e02"
+      ]
+    },
+    {
+      "CodeID": "code-4ef9de00",
+      "CodeType": "Normal",
+      "DisplayText": "s10e02 break",
+      "StringValue": "s10e02_break",
+      "NumericValue": 56,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s10e02 break"
+      ]
+    },
+    {
+      "CodeID": "code-1a7ea68b",
+      "CodeType": "Normal",
+      "DisplayText": "s10e03",
+      "StringValue": "s10e03",
+      "NumericValue": 58,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s10e03"
+      ]
+    },
+    {
+      "CodeID": "code-a137a1c8",
+      "CodeType": "Normal",
+      "DisplayText": "s10e04",
+      "StringValue": "s10e04",
+      "NumericValue": 59,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s10e04"
+      ]
+    },
+    {
+      "CodeID": "code-1e3211ab",
+      "CodeType": "Normal",
+      "DisplayText": "s10e01 schools informing parents",
+      "StringValue": "s10e01_schools_informing_parents",
+      "NumericValue": 55,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s10e01 schools informing parents"
+      ]
+    },
+    {
+      "CodeID": "code-1ca81766",
+      "CodeType": "Normal",
+      "DisplayText": "s10e02 issues in school",
+      "StringValue": "s10e02_issues_in_school",
+      "NumericValue": 57,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s10e02 issues in school"
+      ]
+    },
+    {
+      "CodeID": "code-e0d4687d",
+      "CodeType": "Normal",
+      "DisplayText": "s08 have voice",
+      "StringValue": "s08_have_voice",
+      "NumericValue": 66,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s08 have voice"
+      ]
+    },
+    {
+      "CodeID": "code-9f4fd804",
+      "CodeType": "Normal",
+      "DisplayText": "s08 suggestions",
+      "StringValue": "s08_suggestions",
+      "NumericValue": 67,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s08 suggestions"
+      ]
+    },
+    {
+      "CodeID": "code-cf54f435",
+      "CodeType": "Normal",
+      "DisplayText": "s10 have voice",
+      "StringValue": "s10_have_voice",
+      "NumericValue": 60,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s10 have voice"
+      ]
+    },
+    {
+      "CodeID": "code-b186691f",
+      "CodeType": "Normal",
+      "DisplayText": "s10 suggestions",
+      "StringValue": "s10_suggestions",
+      "NumericValue": 61,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s10 suggestions"
+      ]
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    }
+  ]
+}


### PR DESCRIPTION
Includes demographic code schemes, copied from eu-pcve s01 where possible, or the most recent project to use that demographic code scheme otherwise. Also contains the s01 rqa code schemes from EU-PCVE for testing purposes and in anticipation of the csv recovery needed from eu s01.

Because of the high number of code schemes likely to accumulate in this repo, I've organised them into subdirectories in the code_schemes folder.