### PR TITLE
Add recovered data from March 30th pm

### DIFF
--- a/configurations/eu_pcve_s02_pipeline.py
+++ b/configurations/eu_pcve_s02_pipeline.py
@@ -84,8 +84,13 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
             ],
             timezone="Africa/Mogadishu"
         ),
-        # TODO: Add data from 4pm EAT onwards on March 30th, which currently has too many issue to be processed
-        #       by the usual pre-processing script.
+        CSVSource(
+            "gs://avf-project-datasets/2022/EU-PCVE-S02/recovered_hormuud_2022_03_30_13_00_Z_to_2022_03_30_21_00_Z_de_identified.csv",
+            engagement_db_datasets=[
+                CSVDatasetConfiguration("eu_pcve_s02e02", start_date=isoparse("2022-03-30T16:00:00+03:00"), end_date=isoparse("2022-03-30T24:00:00+03:00"))
+            ],
+            timezone="Africa/Mogadishu"
+        ),
         CSVSource(
             "gs://avf-project-datasets/2022/EU-PCVE-S02/recovered_hormuud_2022_04_01_to_2022_04_02_de_identified.csv",
             engagement_db_datasets=[

--- a/preprocess_recovered_hormuud_messages.py
+++ b/preprocess_recovered_hormuud_messages.py
@@ -227,6 +227,23 @@ if __name__ == "__main__":
              f"{len(rapid_pro_messages) - len(unmatched_messages)} matched successfully, "
              f"{len(unmatched_messages)} unmatched messages remain")
 
+    # Scan remaining messages for possible duplicates
+    log.info(f"Searching remaining {len(unmatched_messages)} unmatched messages for duplicates...")
+    matched_messages_lut = {(msg.urn, msg.text): msg for msg in matched_messages}
+    rapid_pro_messages = unmatched_messages
+    unmatched_messages = []
+    for msg in rapid_pro_messages:
+        if (msg.urn, msg.text) in matched_messages_lut:
+            log.info(f"Found a message urn and text sent at {msg.sent_on}, that was already seen in a message sent "
+                     f"at {matched_messages_lut[(msg.urn, msg.text)].sent_on}")
+            skipped_messages.append(msg)
+        else:
+            unmatched_messages.append(msg)
+    # TODO: Write the duplicated messages to disk so we can use them to de-duplicate the data in the engagement db.
+    log.info(f"Attempted to find duplicates in unmatched messages: "
+             f"Found {len(rapid_pro_messages) - len(unmatched_messages)} messages that were duplicates, "
+             f"{len(unmatched_messages)} unmatched messages remain")
+
     # Finally, search by timestamp, and export these to a log file for manual review.
     # This covers all sorts of weird edge cases, mostly around Hormuud/Excel's handling of special characters.
     rapid_pro_messages = unmatched_messages
@@ -254,23 +271,6 @@ if __name__ == "__main__":
              f"{len(unmatched_messages)} unmatched messages remain")
     log.info(f"Wrote the timestamp-based matches to {timestamp_matches_log_output_csv_path} for manual verification. " 
              f"Please check these carefully")
-
-    # Scanning remaining messages for possible duplicates
-    log.info(f"Searching remaining {len(unmatched_messages)} unmatched messages for duplicates...")
-    matched_messages_lut = {(msg.urn, msg.text): msg for msg in matched_messages}
-    rapid_pro_messages = unmatched_messages
-    unmatched_messages = []
-    for msg in rapid_pro_messages:
-        if (msg.urn, msg.text) in matched_messages_lut:
-            log.info(f"Found a message urn and text sent at {msg.sent_on}, that was already seen in a message sent "
-                     f"at {matched_messages_lut[(msg.urn, msg.text)].sent_on}")
-            skipped_messages.append(msg)
-        else:
-            unmatched_messages.append(msg)
-    # TODO: Write the duplicated messages to disk so we can use them to de-duplicate the data in the engagement db.
-    log.info(f"Attempted to find duplicates in unmatched messages: "
-             f"Found {len(rapid_pro_messages) - len(unmatched_messages)} messages that were duplicates, "
-             f"{len(unmatched_messages)} unmatched messages remain")
 
     if len(unmatched_messages) > 0:
         log.error(f"{len(unmatched_messages)} unmatched messages remain after attempting all automated matching "


### PR DESCRIPTION
This recovery took a long time to figure out because the preprocess script wasn't working very well. I have now traced the problem down to the high number of duplicates saw during this period, and found that by de-duplicating first I can correctly match the messages. I have verified the duplication totals from previous exports are still the same with this re-ordering.

Logs: https://drive.google.com/file/d/1SnW_FNCmUwBfPNTEFabvnZZPncI6ZCWI/view?usp=sharing