### PR TITLE
Add demographics -> TextIt configuration

### DIFF
--- a/configurations/sync_csap_demographics_to_text_it.py
+++ b/configurations/sync_csap_demographics_to_text_it.py
@@ -1,0 +1,67 @@
+from core_data_modules.cleaners import somali
+from core_data_modules.cleaners.codes import Codes
+from dateutil.parser import isoparse
+
+from src.pipeline_configuration_spec import *
+
+PIPELINE_CONFIGURATION = PipelineConfiguration(
+    pipeline_name="CSAP-Somalia-Demographics-To-TextIt",
+    description="Syncs the latest demographics data from the CSAP-Somalia pool to TextIt",
+    engagement_database=EngagementDatabaseClientConfiguration(
+        credentials_file_url="gs://avf-credentials/avf-engagement-databases-firebase-credentials-file.json",
+        database_path="engagement_databases/CSAP_Somalia"
+    ),
+    uuid_table=UUIDTableClientConfiguration(
+        credentials_file_url="gs://avf-credentials/avf-id-infrastructure-firebase-adminsdk-6xps8-b9173f2bfd.json",
+        table_name="avf-global-urn-to-participant-uuid",
+        uuid_prefix="avf-participant-uuid-"
+    ),
+    operations_dashboard=OperationsDashboardConfiguration(
+        credentials_file_url="gs://avf-credentials/avf-dashboards-firebase-adminsdk-gvecb-ef772e79b6.json",
+    ),
+    rapid_pro_target=RapidProTarget(
+        rapid_pro=RapidProClientConfiguration(
+            domain="textit.com",
+            token_file_url="gs://avf-credentials/csap-text-it-token.txt"
+        ),
+        sync_config=EngagementDBToRapidProConfiguration(
+            normal_datasets=[
+                DatasetConfiguration(
+                    engagement_db_datasets=["location"],
+                    rapid_pro_contact_field=ContactField(key="csap_pool_location", label="csap pool location")
+                ),
+                DatasetConfiguration(
+                    engagement_db_datasets=["age"], 
+                    rapid_pro_contact_field=ContactField(key="csap_pool_age", label="csap pool age")
+                ),
+                DatasetConfiguration(
+                    engagement_db_datasets=["gender"], 
+                    rapid_pro_contact_field=ContactField(key="csap_pool_gender", label="csap pool gender")
+                ),
+                DatasetConfiguration(
+                    engagement_db_datasets=["household_language"], 
+                    rapid_pro_contact_field=ContactField(key="csap_pool_household_language", label="csap pool household language")
+                ),
+                DatasetConfiguration(
+                    engagement_db_datasets=["recently_displaced"], 
+                    rapid_pro_contact_field=ContactField(key="csap_pool_recently_displaced", label="csap pool recently displaced")
+                ),
+                DatasetConfiguration(
+                    engagement_db_datasets=["in_idp_camp"],
+                    rapid_pro_contact_field=ContactField(key="csap_pool_in_idp_camp", label="csap pool in idp camp")
+                ),
+                DatasetConfiguration(
+                    engagement_db_datasets=["livelihood"],
+                    rapid_pro_contact_field=ContactField(key="csap_pool_livelihood", label="csap pool livelihood")
+                ),
+            ],
+            consent_withdrawn_dataset=None,
+            write_mode=WriteModes.CONCATENATE_TEXTS,
+            allow_clearing_fields=True
+        )
+    ),
+    archive_configuration=ArchiveConfiguration(
+        archive_upload_bucket="gs://pipeline-execution-backup-archive",
+        bucket_dir_path="2022/CSAP-Somalia-Demographics-To-TextIt"
+    )
+)


### PR DESCRIPTION
This can re-run between seasons/projects with only minor changes.

Adapted from the initial create_csap_pool configuration.