### PR TITLE
Recover s03 data

### DIFF
--- a/configurations/docker_image_name.txt
+++ b/configurations/docker_image_name.txt
@@ -1,1 +1,1 @@
-ghcr.io/africasvoices/engagement-data-pipeline:v2.2.0
+ghcr.io/africasvoices/engagement-data-pipeline:v3.0.0

--- a/configurations/eu_pcve_s03_pipeline.py
+++ b/configurations/eu_pcve_s03_pipeline.py
@@ -48,6 +48,18 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
             )
         )
     ],
+    csv_sources=[
+        CSVSource(
+            "gs://avf-project-datasets/2022/EU-PCVE-S03/recovered_hormuud_2022_09_de_identified.csv",
+            engagement_db_datasets=[
+                CSVDatasetConfiguration("eu_pcve_s03e01", start_date=isoparse("2022-09-04T00:00:00+03:00"), end_date=isoparse("2022-09-10T24:00:00+03:00")),
+                CSVDatasetConfiguration("eu_pcve_s03e02", start_date=isoparse("2022-09-11T00:00:00+03:00"), end_date=isoparse("2022-09-17T24:00:00+03:00")),
+                CSVDatasetConfiguration("eu_pcve_s03e03", start_date=isoparse("2022-09-18T00:00:00+03:00"), end_date=isoparse("2022-09-24T24:00:00+03:00")),
+                CSVDatasetConfiguration("eu_pcve_s03_closeout", start_date=isoparse("2022-09-25T00:00:00+03:00"), end_date=isoparse("2022-09-30T24:00:00+03:00"))
+            ],
+            timezone="Africa/Mogadishu"
+        )
+    ],
     rapid_pro_target=RapidProTarget(
         rapid_pro=RapidProClientConfiguration(
             domain="textit.com",

--- a/preprocess_recovered_hormuud_messages.py
+++ b/preprocess_recovered_hormuud_messages.py
@@ -135,16 +135,23 @@ if __name__ == "__main__":
 
     # Define the maximum time difference we can observe between a message in rapid pro and in the recovery csv for it
     # to count as a match.
-    max_time_delta = timedelta(minutes=5)
-    if start_date >= isoparse("2022-04-03T00:00+03:00"):
-        # Since the April 3rd, when the short code was "fixed", we've been experiencing a longer lag.
-        # If processing data on or since that date, use a 7 minute timedelta when searching rather than 5.
-        # (We leave the old 5 minute timedelta for older dates so that this script will still give consistent results
-        #  for exports made previously)
+    if end_date < isoparse("2022-04-03T00:00+03:00"):
+        # During Pool-CSAP-Somalia projects that took place before April 3rd, the realtime connection was extremely
+        # unreliable (typical message loss rate was 50%), but the delay was typically about 4 minutes, and all
+        # less than 5.
+        max_time_delta = timedelta(minutes=5)
+    elif start_date >= isoparse("2022-04-03T00:00+03:00") and end_date < isoparse("2022-09-01T00:00+03:00"):
+        # When the realtime connection was improved from April 3rd 2022, message loss rate decreased to 1-2% but
+        # the maximum delay slightly increased. Use 7 minutes for messages received since that date.
         max_time_delta = timedelta(minutes=7)
+    elif start_date >= isoparse("2022-09-01T00:00+03:00"):
+        # Since at least September 1st 2022 (and possibly earlier, when there were no projects running on the short
+        # code), loss-rate remains at ~2% but the maximum delay has increased significantly in a small number of cases.
+        max_time_delta = timedelta(minutes=110)
     else:
-        # Prevent accidents in case this script is reused across the time delta transition.
-        assert end_date < isoparse("2022-04-03T00:00+03:00")
+        assert False, "Unsupported data-range due to data crossing a max_time_delta definition boundary. " \
+                      "Either check the dates, update the date-ranges in the source code, or break the recovery " \
+                      "dataset into a chunks for each supported time range."
     log.info(f"Using maximum message time delta of {max_time_delta}")
 
     # Get messages from Rapid Pro and from the recovery csv

--- a/preprocess_recovered_hormuud_messages.py
+++ b/preprocess_recovered_hormuud_messages.py
@@ -66,9 +66,14 @@ def get_incoming_hormuud_messages_from_recovery_csv(csv_path,
                 datetime.strptime(msg["ReceivedOn"], "%d/%m/%Y %H:%M:%S.%f")
             )
         except ValueError:
-            msg["timestamp"] = pytz.timezone("Africa/Mogadishu").localize(
-                datetime.strptime(msg["ReceivedOn"], "%d/%m/%Y %H:%M:%S")
-            )
+            try:
+                msg["timestamp"] = pytz.timezone("Africa/Mogadishu").localize(
+                    datetime.strptime(msg["ReceivedOn"], "%d/%m/%Y %H:%M:%S")
+                )
+            except ValueError:
+                msg["timestamp"] = pytz.timezone("Africa/Mogadishu").localize(
+                    datetime.strptime(msg["ReceivedOn"], "%Y-%m-%d %H:%M:%S")
+                )
 
     if received_after_inclusive is not None:
         log.info(f"Filtering out messages sent before {received_after_inclusive}...")


### PR DESCRIPTION
The breaking change in v3.0.0 of the engagement data pipeline does not affect any of the configurations in this repo.

The pre-processing script found 18116 exact matches, 2030 excel-mangled matches, 1 duplicate, 16 timestamp matches with a new, much higher max time-delta, and 392 unmatched messages to be added (of which about 40% were Somnet, who were never connected to us in s03).